### PR TITLE
issue #2733 - add more cache stats

### DIFF
--- a/fhir-profile/src/main/java/com/ibm/fhir/profile/ProfileSupport.java
+++ b/fhir-profile/src/main/java/com/ibm/fhir/profile/ProfileSupport.java
@@ -212,7 +212,11 @@ public final class ProfileSupport {
 
     public static Map<String, Binding> getBindingMap(String url) {
         Map<String, Map<String, Binding>> bindingMapCache = CacheManager.getCacheAsMap(BINDING_CACHE_NAME, BINDING_CACHE_CONFIG);
-        return bindingMapCache.computeIfAbsent(url, ProfileSupport::computeBindingMap);
+        try {
+            return bindingMapCache.computeIfAbsent(url, ProfileSupport::computeBindingMap);
+        } finally {
+            CacheManager.reportCacheStats(log, BINDING_CACHE_NAME);
+        }
     }
 
     public static List<Constraint> getConstraints(List<String> urls, Class<?> type) {
@@ -280,7 +284,11 @@ public final class ProfileSupport {
         CacheKey key = key(url + "|" + version);
         Map<CacheKey, List<Constraint>> constraintCache = CacheManager.getCacheAsMap(CONSTRAINT_CACHE_NAME, CONSTRAINT_CACHE_CONFIG);
 
-        return constraintCache.computeIfAbsent(key, k -> computeConstraints(profile, type));
+        try {
+            return constraintCache.computeIfAbsent(key, k -> computeConstraints(profile, type));
+        } finally {
+            CacheManager.reportCacheStats(log, CONSTRAINT_CACHE_NAME);
+        }
     }
 
     public static ElementDefinition getElementDefinition(String path) {
@@ -295,7 +303,11 @@ public final class ProfileSupport {
 
     public static Map<String, ElementDefinition> getElementDefinitionMap(String url) {
         Map<String, Map<String, ElementDefinition>> elementDefinitionMapCache = CacheManager.getCacheAsMap(ELEMENT_DEF_CACHE_NAME, ELEMENT_DEF_CACHE_CONFIG);
-        return elementDefinitionMapCache.computeIfAbsent(url, ProfileSupport::computeElementDefinitionMap);
+        try {
+            return elementDefinitionMapCache.computeIfAbsent(url, ProfileSupport::computeElementDefinitionMap);
+        } finally {
+            CacheManager.reportCacheStats(log, ELEMENT_DEF_CACHE_NAME);
+        }
     }
 
     public static Set<String> getConstraintKeys(StructureDefinition structureDefinition) {

--- a/term/fhir-term/src/main/java/com/ibm/fhir/term/util/CodeSystemSupport.java
+++ b/term/fhir-term/src/main/java/com/ibm/fhir/term/util/CodeSystemSupport.java
@@ -213,7 +213,11 @@ public final class CodeSystemSupport {
         CacheKey key = key(codeSystem, code);
         Map<CacheKey, Set<java.lang.String>> cacheAsMap = CacheManager.getCacheAsMap(ANCESTORS_AND_SELF_CACHE_NAME, ANCESTORS_AND_SELF_CACHE_CONFIG);
         CacheManager.reportCacheStats(LOG, ANCESTORS_AND_SELF_CACHE_NAME);
-        return cacheAsMap.computeIfAbsent(key, k -> computeAncestorsAndSelf(codeSystem, code));
+        try {
+            return cacheAsMap.computeIfAbsent(key, k -> computeAncestorsAndSelf(codeSystem, code));
+        } finally {
+            CacheManager.reportCacheStats(LOG, ANCESTORS_AND_SELF_CACHE_NAME);
+        }
     }
 
     /**
@@ -462,7 +466,11 @@ public final class CodeSystemSupport {
         CacheKey key = key(codeSystem, code);
         Map<CacheKey, Set<java.lang.String>> cacheAsMap = CacheManager.getCacheAsMap(DESCENDANTS_AND_SELF_CACHE_NAME, DESCENDANTS_AND_SELF_CACHE_CONFIG);
         CacheManager.reportCacheStats(LOG, DESCENDANTS_AND_SELF_CACHE_NAME);
-        return cacheAsMap.computeIfAbsent(key, k -> computeDescendantsAndSelf(codeSystem, code));
+        try {
+            return cacheAsMap.computeIfAbsent(key, k -> computeDescendantsAndSelf(codeSystem, code));
+        } finally {
+            CacheManager.reportCacheStats(LOG, DESCENDANTS_AND_SELF_CACHE_NAME);
+        }
     }
 
     /**

--- a/term/fhir-term/src/main/java/com/ibm/fhir/term/util/ValueSetSupport.java
+++ b/term/fhir-term/src/main/java/com/ibm/fhir/term/util/ValueSetSupport.java
@@ -94,7 +94,11 @@ public final class ValueSetSupport {
         }
         java.lang.String url = cacheKey(valueSet);
         Map<java.lang.String, Map<java.lang.String, Set<java.lang.String>>> cacheAsMap = CacheManager.getCacheAsMap(CODE_SET_MAP_CACHE_NAME, CODE_SET_MAP_CACHE_CONFIG);
-        return cacheAsMap.computeIfAbsent(url, k -> computeCodeSetMap(valueSet));
+        try {
+            return cacheAsMap.computeIfAbsent(url, k -> computeCodeSetMap(valueSet));
+        } finally {
+            CacheManager.reportCacheStats(log, CODE_SET_MAP_CACHE_NAME);
+        }
     }
 
     /**
@@ -109,11 +113,11 @@ public final class ValueSetSupport {
 
     /**
      * Compute the code set map cache key for the given value set.
-     * 
+     *
      * @param valueSet
      *     the value set
-     * 
-     * @return 
+     *
+     * @return
      *     computed cache key
      */
     private static java.lang.String cacheKey(ValueSet valueSet) {


### PR DESCRIPTION
This follows the pattern from #2801 and adds cache stat output for the managed caches in the following classes:
* ProfileSupport
* CodeSystemSupport
* ValueSetSupport

It would be nice if we could restrict the cache stat output to just cache misses (or similar) as the current approach is VERY noisy when they are enabled.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>