### PR TITLE
Restore lost jackson core classes to CQL operations

### DIFF
--- a/cql/operation/fhir-operation-cpg/pom.xml
+++ b/cql/operation/fhir-operation-cpg/pom.xml
@@ -120,6 +120,7 @@
                                     <include>info.cqframework:*</include>
                                     <include>org.fhir:ucum</include>
                                     <include>xpp3</include>
+                                    <include>com.fasterxml.jackson.core:*</include>
                                     <include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations</include>
                                     <include>org.jvnet.jaxb2_commons</include>
                                     <include>org.eclipse.persistence</include>

--- a/cql/operation/fhir-operation-cqf/pom.xml
+++ b/cql/operation/fhir-operation-cqf/pom.xml
@@ -132,6 +132,7 @@
                                     <include>info.cqframework:*</include>
                                     <include>org.fhir:ucum</include>
                                     <include>xpp3</include>
+                                    <include>com.fasterxml.jackson.core:*</include>
                                     <include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations</include>
                                     <include>org.jvnet.jaxb2_commons</include>
                                     <include>org.eclipse.persistence</include>


### PR DESCRIPTION
While preparing for Hackathon, I noticed the the CQL operations were no longer functioning. It appears that the jackson core modules that used to be part of the server have been removed. I added the dependencies back into the include list for the cql operation shaded JARs.

Signed-off-by: Corey Sanders <corey.thecolonel@gmail.com>