### PR TITLE
Reduce the default min heap size and remove the default max heap size

### DIFF
--- a/fhir-server/liberty-config/configDropins/defaults/jvm.options
+++ b/fhir-server/liberty-config/configDropins/defaults/jvm.options
@@ -1,0 +1,2 @@
+# Set a fixed, higher than default, initial heap size that could serve a moderate workload
+-Xms768M

--- a/fhir-server/liberty-config/configDropins/disabled/jvm.options
+++ b/fhir-server/liberty-config/configDropins/disabled/jvm.options
@@ -1,7 +1,8 @@
-# Reduced heap size for constrained environments
-
-# Initial heap size (same as max so no reallocations will occur)
--Xms3072M
-
-# Maximum heap size
+# Set a fixed max heap size
 -Xmx3072M
+
+# Turn on verbose classloading
+#-verbose:class
+
+# Turn on verbose garbage collection
+#-verbose:gc

--- a/fhir-server/liberty-config/jvm.options
+++ b/fhir-server/liberty-config/jvm.options
@@ -15,12 +15,3 @@
 
 # Prevents Apache Xerces from overactively using the service loader to find a class
 -Dorg.apache.xml.dtm.DTMManager=org.apache.xml.dtm.ref.DTMManagerDefault
-
-# Initial heap size (same as max so no reallocations will occur)
--Xms4096M
-
-# Maximum heap size
--Xmx4096M
-
-# Uncomment to turn on verbose classloading
-#-verbose:class


### PR DESCRIPTION
For historical reasons we were setting the initial heap size to the same
value as the max heap size: 4GiB.
However, based on experimentation, our memory pool usage is only around
512MB for a lightly used ingestion workload.
The cost dynamics of cloud make it more important to set an appropriate
initial heap size and memory management in the JVM has gotten better
over time.

As for the max heap size, OpenJ9 has intelligent defaults when running
within a container, and so we should use those instead of guessing at a
default of our own:
https://www.eclipse.org/openj9/docs/xxusecontainersupport

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>