### PR TITLE
Remove pluginManagement section from fhir-model pom

### DIFF
--- a/fhir-model/pom.xml
+++ b/fhir-model/pom.xml
@@ -63,23 +63,6 @@
     </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>com.ibm.fhir</groupId>
-                    <artifactId>fhir-tools</artifactId>
-                    <version>${fhir-tools.version}</version>
-                    <dependencies>
-                        <!-- javax.json implementation -->
-                        <dependency>
-                            <groupId>org.glassfish</groupId>
-                            <artifactId>jakarta.json</artifactId>
-                            <version>1.1.5</version>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
I'm not sure why we had that here to begin with, but I
confirmed that `build/gen-model.sh` still works just fine for
regenerating the classes after removing it.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>