### PR TITLE
set -e to use exit code from the java command after failure

### DIFF
--- a/fhir-install/src/main/docker/ibm-fhir-bucket-tool/run.sh
+++ b/fhir-install/src/main/docker/ibm-fhir-bucket-tool/run.sh
@@ -6,5 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # ----------------------------------------------------------------------------
 
+set -e -o pipefail
+
 /opt/java/openjdk/bin/java -jar /opt/ibm/fhir/bucket/fhir-bucket-*-cli.jar "$@"
 # EOF


### PR DESCRIPTION
I'd like the bucket container to exit with a non-zero status if the java process does

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>