### PR TITLE
Fix fhirVersion in the CapabilityStatement

### DIFF
--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/CapabilitiesVersionTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/CapabilitiesVersionTest.java
@@ -84,7 +84,7 @@ public class CapabilitiesVersionTest extends FHIRServerTestBase {
                 }
             }
             break;
-        case VERSION_4_3_0_CIBUILD:
+        case VERSION_4_3_0:
             // nothing to verify at the moment
             break;
         default:
@@ -100,13 +100,13 @@ public class CapabilitiesVersionTest extends FHIRServerTestBase {
         return new Object[][] {
             { "default", null, FHIRVersion.VERSION_4_0_1 },
             { "default", "4.0", FHIRVersion.VERSION_4_0_1 },
-            { "default", "4.3", FHIRVersion.VERSION_4_3_0_CIBUILD },
-            { "tenant1", null, FHIRVersion.VERSION_4_3_0_CIBUILD },
+            { "default", "4.3", FHIRVersion.VERSION_4_3_0 },
+            { "tenant1", null, FHIRVersion.VERSION_4_3_0 },
             { "tenant1", "4.0", FHIRVersion.VERSION_4_0_1 },
-            { "tenant1", "4.3", FHIRVersion.VERSION_4_3_0_CIBUILD },
+            { "tenant1", "4.3", FHIRVersion.VERSION_4_3_0 },
             { "tenant2", null, FHIRVersion.VERSION_4_0_1 },
             { "tenant2", "4.0", FHIRVersion.VERSION_4_0_1 },
-            { "tenant2", "4.3", FHIRVersion.VERSION_4_3_0_CIBUILD }
+            { "tenant2", "4.3", FHIRVersion.VERSION_4_3_0 }
         };
     }
 }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Capabilities.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Capabilities.java
@@ -564,7 +564,7 @@ public class Capabilities extends FHIRResource {
                 .status(PublicationStatus.ACTIVE)
                 .date(DateTime.now(ZoneOffset.UTC))
                 .kind(CapabilityStatementKind.INSTANCE)
-                .fhirVersion(fhirVersion == FHIRVersionParam.VERSION_43 ? FHIRVersion.VERSION_4_3_0_CIBUILD : FHIRVersion.VERSION_4_0_1)
+                .fhirVersion(fhirVersion == FHIRVersionParam.VERSION_43 ? FHIRVersion.VERSION_4_3_0 : FHIRVersion.VERSION_4_0_1)
                 .format(format)
                 .patchFormat(Code.of(FHIRMediaType.APPLICATION_JSON_PATCH),
                              Code.of(FHIRMediaType.APPLICATION_FHIR_JSON),


### PR DESCRIPTION
Use "4.3.0" instead of "4.3.0-cibuild"

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>