### PR TITLE
issue #3712 - check all CodeSystem concept designations

### DIFF
--- a/term/fhir-term/src/test/java/com/ibm/fhir/term/service/test/FHIRTermServiceTest.java
+++ b/term/fhir-term/src/test/java/com/ibm/fhir/term/service/test/FHIRTermServiceTest.java
@@ -13,6 +13,7 @@ import static com.ibm.fhir.term.util.ConceptMapSupport.getConceptMap;
 import static com.ibm.fhir.term.util.ValueSetSupport.getContains;
 import static com.ibm.fhir.term.util.ValueSetSupport.getValueSet;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -584,5 +585,81 @@ public class FHIRTermServiceTest {
         TranslationOutcome outcome = FHIRTermService.getInstance().translate(conceptMap, coding);
 
         assertEquals(outcome, expected);
+    }
+
+    @Test
+    public void testValidateDisplay_caseSensitive() throws Exception {
+        CodeSystem codeSystem = getCodeSystem("http://ibm.com/fhir/CodeSystem/cs1");
+        Coding coding = Coding.builder()
+                .system(Uri.of("http://ibm.com/fhir/CodeSystem/cs1"))
+                .code(Code.of("a"))
+                .build();;
+        ValidationOutcome outcome;
+
+        coding = coding.toBuilder()
+                .display("Concept a")
+                .build();
+        outcome = FHIRTermService.getInstance().validateCode(codeSystem, coding);
+        assertTrue(outcome.getResult().getValue(),
+                (outcome.getMessage() != null) ? outcome.getMessage().getValue() : outcome.getDisplay().getValue());
+
+        coding = coding.toBuilder()
+                .display("a")
+                .build();
+        outcome = FHIRTermService.getInstance().validateCode(codeSystem, coding);
+        assertTrue(outcome.getResult().getValue(),
+                (outcome.getMessage() != null) ? outcome.getMessage().getValue() : outcome.getDisplay().getValue());
+
+        coding = Coding.builder()
+                .display("Concept A")
+                .build();
+        outcome = FHIRTermService.getInstance().validateCode(codeSystem, coding);
+        assertFalse(outcome.getResult().getValue(),
+                (outcome.getMessage() != null) ? outcome.getMessage().getValue() : outcome.getDisplay().getValue());
+
+        coding = Coding.builder()
+                .display("A")
+                .build();
+        outcome = FHIRTermService.getInstance().validateCode(codeSystem, coding);
+        assertFalse(outcome.getResult().getValue(),
+                (outcome.getMessage() != null) ? outcome.getMessage().getValue() : outcome.getDisplay().getValue());
+    }
+
+    @Test
+    public void testValidateDisplay_caseInsensitive() throws Exception {
+        CodeSystem codeSystem = getCodeSystem("http://ibm.com/fhir/CodeSystem/cs2");
+        Coding coding = Coding.builder()
+                .system(Uri.of("http://ibm.com/fhir/CodeSystem/cs2"))
+                .code(Code.of("d"))
+                .build();
+        ValidationOutcome outcome;
+
+        coding = coding.toBuilder()
+                .display("Concept d")
+                .build();
+        outcome = FHIRTermService.getInstance().validateCode(codeSystem, coding);
+        assertTrue(outcome.getResult().getValue(),
+                (outcome.getMessage() != null) ? outcome.getMessage().getValue() : outcome.getDisplay().getValue());
+
+        coding = coding.toBuilder()
+                .display("d")
+                .build();
+        outcome = FHIRTermService.getInstance().validateCode(codeSystem, coding);
+        assertTrue(outcome.getResult().getValue(),
+                (outcome.getMessage() != null) ? outcome.getMessage().getValue() : outcome.getDisplay().getValue());
+
+        coding = coding.toBuilder()
+                .display("Concept D")
+                .build();
+        outcome = FHIRTermService.getInstance().validateCode(codeSystem, coding);
+        assertTrue(outcome.getResult().getValue(),
+                (outcome.getMessage() != null) ? outcome.getMessage().getValue() : outcome.getDisplay().getValue());
+
+        coding = coding.toBuilder()
+                .display("D")
+                .build();
+        outcome = FHIRTermService.getInstance().validateCode(codeSystem, coding);
+        assertTrue(outcome.getResult().getValue(),
+                (outcome.getMessage() != null) ? outcome.getMessage().getValue() : outcome.getDisplay().getValue());
     }
 }

--- a/term/fhir-term/src/test/resources/fhir/term/service/test/package/CodeSystem-cs1.json
+++ b/term/fhir-term/src/test/resources/fhir/term/service/test/package/CodeSystem-cs1.json
@@ -10,7 +10,10 @@
     "concept": [
         {
             "code": "a",
-            "display": "Concept a"
+            "display": "Concept a",
+            "designation": [{
+                "value": "a"
+            }]
         },
         {
             "code": "b",

--- a/term/fhir-term/src/test/resources/fhir/term/service/test/package/CodeSystem-cs2.json
+++ b/term/fhir-term/src/test/resources/fhir/term/service/test/package/CodeSystem-cs2.json
@@ -10,7 +10,10 @@
     "concept": [
         {
             "code": "d",
-            "display": "Concept d"
+            "display": "Concept d",
+            "designation": [{
+                "value": "d"
+            }]
         },
         {
             "code": "e",


### PR DESCRIPTION
1. Split `validateDisplay` into two flavors; now
validateCode(CodeSystem, Coding, ValidationParameters) will use the
passed CodeSystem to determine case sensitivity (instead of looking it
up via the registry)

2. When the Coding.display doesn't match the lookup display, we now look
for a match within the CodesSystem.concept.designation values before
calling it invalid.

3. Added a designation to a couple sample code systems and added
testValidateDisplay tests for both case-sensitive and case-insensitive
behavior.

Signed-off-by: Lee Surprenant <lmsurpre@merative.com>