### PR TITLE
issue #3503 - special case underlying $everything "Forbidden" exceptions

### DIFF
--- a/conformance/fhir-core-r4b/pom.xml
+++ b/conformance/fhir-core-r4b/pom.xml
@@ -26,13 +26,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>fhir-model</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.skyscreamer</groupId>
             <artifactId>jsonassert</artifactId>
             <scope>test</scope>

--- a/fhir-server-test/pom.xml
+++ b/fhir-server-test/pom.xml
@@ -67,6 +67,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>java-jwt</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- Use the Grizzly container instead due to https://github.com/eclipse-ee4j/tyrus/issues/676 -->
         <!-- <dependency>
             <groupId>org.glassfish.tyrus.bundles</groupId>

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/smart/SMARTTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/smart/SMARTTest.java
@@ -1,0 +1,80 @@
+package com.ibm.fhir.server.test.smart;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.fail;
+
+import java.util.UUID;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTCreator.Builder;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.beust.jcommander.Strings;
+import com.ibm.fhir.client.impl.FHIROAuth2Authenticator;
+import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.model.resource.OperationOutcome;
+import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.type.code.IssueType;
+import com.ibm.fhir.server.test.FHIRServerTestBase;
+
+public class SMARTTest extends FHIRServerTestBase {
+    boolean smartEnabled = false;
+
+    @BeforeClass
+    public void testGetSmartConfiguration() {
+        Response response = getWebTarget().path("/.well-known/smart-configuration").request().get();
+        switch(response.getStatus()) {
+        case 200:
+            smartEnabled = true;
+            return;
+        case 401:
+        case 404:
+            // no smart-configuration endpoint, so SMART isn't enabled
+            return;
+        default:
+            fail("Unexpected " + response.getStatus() + " response from /.well-known/smart-configuration");
+        }
+    }
+
+    @Test
+    public void testPatientEverything_invalid() throws Exception {
+        if (!smartEnabled) {
+            throw new SkipException("The server is not configured for SMART-on-FHIR");
+        }
+
+        String patientId = UUID.randomUUID().toString();
+        String jwt = jwt(patientId, "patient/Patient.*");
+        Entity<Resource> entity = Entity.entity(Patient.builder().id(patientId).build(), FHIRMediaType.APPLICATION_FHIR_JSON);
+
+        WebTarget target = getWebTarget();
+        target.register(new FHIROAuth2Authenticator(jwt));
+        Response response = target.path("Patient/" + patientId).request().put(entity);
+        assertEquals(response.getStatus(), 201);
+
+        response = target.path("Patient/" + patientId + "/$everything").request().get();
+        assertEquals(response.getStatus(), 403);
+        OperationOutcome oo = response.readEntity(OperationOutcome.class);
+        assertFalse(oo.getIssue().isEmpty());
+        assertEquals(oo.getIssue().get(0).getCode(), IssueType.FORBIDDEN);
+    }
+
+    /**
+     * Factory method to create JWTs that are compatible with the FHIR Server SMART support
+     */
+    private static String jwt(String patientId, String... scope) {
+        Builder jwt = JWT.create()
+                .withClaim("patient_id", patientId)
+                .withClaim("scope", Strings.join(" ", scope));
+
+        return jwt.sign(Algorithm.none());
+    }
+}

--- a/fhir-server-test/src/test/java/testng.xml
+++ b/fhir-server-test/src/test/java/testng.xml
@@ -77,4 +77,9 @@
             <package name="com.ibm.fhir.server.test.cqf" />
         </packages>
     </test>
+    <test name="SmartOnFhirEnabledTests">
+        <packages>
+            <package name="com.ibm.fhir.server.test.smart" />
+        </packages>
+    </test>
 </suite>

--- a/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
+++ b/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
@@ -571,7 +571,7 @@ public class AuthzPolicyEnforcementTest {
             assertEquals(e.getIssues().size(), 1);
             assertEquals(e.getIssues().get(0).getCode(), IssueType.FORBIDDEN);
             assertEquals(e.getIssues().get(0).getDetails().getText().getValue(),
-                "read permission for 'AllergyIntolerance' is not granted by any of the provided scopes: " +
+                "read permission for 'AllergyIntolerance' is not granted by any of the provided SMART scopes: " +
                 "[[" + scopeString.replace(" ", ", ") + "]]");
         }
 
@@ -671,7 +671,7 @@ public class AuthzPolicyEnforcementTest {
             assertEquals(e.getIssues().size(), 1);
             assertEquals(e.getIssues().get(0).getCode(), IssueType.FORBIDDEN);
             assertEquals(e.getIssues().get(0).getDetails().getText().getValue(),
-                "read permission for 'AllergyIntolerance' is not granted by any of the provided scopes: " +
+                "read permission for 'AllergyIntolerance' is not granted by any of the provided SMART scopes: " +
                 "[[" + scopeString.replace(" ", ", ") + "]]");
         }
 
@@ -688,7 +688,7 @@ public class AuthzPolicyEnforcementTest {
             assertEquals(e.getIssues().size(), 1);
             assertEquals(e.getIssues().get(0).getCode(), IssueType.FORBIDDEN);
             assertEquals(e.getIssues().get(0).getDetails().getText().getValue(),
-                "read permission for 'Medication' is not granted by any of the provided scopes: " +
+                "read permission for 'Medication' is not granted by any of the provided SMART scopes: " +
                 "[[" + scopeString.replace(" ", ", ") + "]]");
         }
     }


### PR DESCRIPTION
In addition to the change, I added a new e2e test package under
fhir-server-test to confirm the fix. The test will conditionally execute
based on whether the server advertises its
.well-known/smart-configuration (which we only serve when its
configured). There's a ton of cases we could add, but for now I just
wanted to cover the specific case in #3503. Previously, we had only unit
tests for the fhir-smart interceptor.

I also removed an unused private method from the fhir-smart interceptor.

Finally, I snuck in a couple very minor updates:
* removed an unused test-jar dependency from fhir-core-r4b
* a single word change to a specific AuthzPolicyEnforcement message to
hint that only "SMART" scopes are echoed back to the client (and not
other scopes that may have been passed)

Signed-off-by: Lee Surprenant <lmsurpre@merative.com>