### PR TITLE
issue #3655 - throw from ServerFHIRRetrieveProvider for failed reads

### DIFF
--- a/cql/fhir-cql-server/src/main/java/com/ibm/fhir/cql/engine/server/retrieve/ServerFHIRRetrieveProvider.java
+++ b/cql/fhir-cql-server/src/main/java/com/ibm/fhir/cql/engine/server/retrieve/ServerFHIRRetrieveProvider.java
@@ -80,7 +80,7 @@ public class ServerFHIRRetrieveProvider extends SearchParameterFHIRRetrieveProvi
                 while(it.hasNext()) {
                     results.add(it.next());
                 }
-            } else {
+            } else if (resource != null) {
                 results.add(resource);
             }
         }
@@ -97,6 +97,9 @@ public class ServerFHIRRetrieveProvider extends SearchParameterFHIRRetrieveProvi
                 SingleResourceResult<?> result = resourceHelpers.doRead(dataType, id);
                 if (result.isSuccess()) {
                     resource = result.getResource();
+                } else {
+                    // For backwards-compatibility with our old behavior
+                    throw new RuntimeException("Resource '" + dataType + "/" + id + "' not found.");
                 }
             } else {
                 resource = resourceHelpers.doSearch(dataType, /*compartment=*/null, /*compartmentId=*/null, queryParameters, DUMMY_REQUEST_URI);


### PR DESCRIPTION
In my opinion, neither the old behavior (500 server error) nor the new
behavior (200 OK with a null expression result) are ideal.
However, since we didn't intend to change it, I've restored the previous
behavior for now.
The most relevant advantage is we'll now get a reasonable error message
when the user tries to evaluate expressions on resources that don't
exist.

Signed-off-by: Lee Surprenant <lmsurpre@merative.com>