### PR TITLE
tweak postgres settings

### DIFF
--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -7,6 +7,8 @@ volumes:
 services:
   postgres:
     image: postgres:15beta2
+    # https://dba.stackexchange.com/q/275378/46472
+    shm_size: 2GB
     volumes:
       - type: volume
         source: pgdata
@@ -24,8 +26,11 @@ services:
       interval: 5s
       timeout: 4s
       retries: 3
+    # "Larger settings for shared_buffers usually require a corresponding increase in max_wal_size, 
+    # to spread out the process of writing large quantities of new or changed data over a longer period of time."
     command: "
-      -c shared_buffers=2GB
+      -c shared_buffers=1GB
+      -c max_wal_size=2GB
       -c max_connections=100
       -c max_prepared_transactions=100
       -c max_locks_per_transaction=128


### PR DESCRIPTION
Our other postgres compose environments use an init script that modifies a lot of postgres settings as follows:
```
    sed -i -e"s/^max_connections = 100.*$/max_connections = 100/" /db/data/postgresql.conf
    sed -i -e"s/^max_prepared_transactions = 100.*$/max_prepared_transactions = 100/" /db/data/postgresql.conf
    sed -i -e"s/^max_locks_per_transaction = .*$/max_locks_per_transaction = 128/" /db/data/postgresql.conf
    sed -i -e"s/^shared_buffers =.*$/shared_buffers = 4GB/" /db/data/postgresql.conf
    sed -i -e"s/^#effective_cache_size = 128MB.*$/effective_cache_size = 2GB/" /db/data/postgresql.conf
    sed -i -e"s/^#work_mem = 1MB.*$/work_mem = 1MB/" /db/data/postgresql.conf
    sed -i -e"s/^#maintenance_work_mem = 16MB.*$/maintenance_work_mem = 512MB/" /db/data/postgresql.conf
    sed -i -e"s/^#checkpoint_segments = .*$/checkpoint_segments = 32/" /db/data/postgresql.conf
    sed -i -e"s/^#checkpoint_completion_target = 0.5.*$/checkpoint_completion_target = 0.7/" /db/data/postgresql.conf
    sed -i -e"s/^#wal_buffers =.*$/wal_buffers = 16MB/" /db/data/postgresql.conf
    sed -i -e"s/^#default_statistics_target = 100.*$/default_statistics_target = 100/" /db/data/postgresql.conf
```

For the new CI work, I took a more minimalistic approach...starting with the base postgresql image and only modifying what I needed to...mostly just setting a larger `shared_buffers`.
However, I found advice online about
1. setting shm_size higher than shared_buffers; and
2. increasing max_wal_size when you increase shared_buffers

So this PR adjusts the config accordingly.  If it works well, I'd like to try this config in our other compose environments (including `/demo`) as well.

Signed-off-by: Lee Surprenant <lmsurpre@merative.com>