### PR TITLE
issue #3787 allow afterSearch interceptor to modify resource

### DIFF
--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/SingleResourceResultTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/SingleResourceResultTest.java
@@ -1,0 +1,70 @@
+/*
+ * (C) Copyright IBM Corp. 2022
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+ 
+package com.ibm.fhir.persistence.test;
+
+import static com.ibm.fhir.model.type.String.string;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.model.type.Id;
+import com.ibm.fhir.model.type.Instant;
+import com.ibm.fhir.model.type.Meta;
+import com.ibm.fhir.model.type.Narrative;
+import com.ibm.fhir.model.type.Reference;
+import com.ibm.fhir.model.type.Xhtml;
+import com.ibm.fhir.model.type.code.NarrativeStatus;
+import com.ibm.fhir.persistence.InteractionStatus;
+import com.ibm.fhir.persistence.SingleResourceResult;
+
+/**
+ * Unit test for SingleResourceResult
+ */
+public class SingleResourceResultTest {
+
+    @Test
+    public void testReplace() {
+        Patient patient = Patient.builder()
+                .meta(Meta.builder()
+                    .lastUpdated(Instant.now())
+                    .versionId(Id.of("1"))
+                    .build())
+                .generalPractitioner(Reference.builder()
+                    .reference(string("Practitioner/1"))
+                    .build())
+                .text(Narrative.builder()
+                    .div(Xhtml.of("<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"))
+                    .status(NarrativeStatus.GENERATED)
+                    .build())
+                .build();
+        SingleResourceResult<Patient> srr = new SingleResourceResult.Builder<Patient>()
+                .interactionStatus(InteractionStatus.READ)
+                .resource(patient)
+                .success(true)
+                .deleted(false)
+                .build();
+        assertTrue(srr.getResource() == patient);
+        assertTrue(srr.isSuccess());
+        assertFalse(srr.isDeleted());
+        assertEquals(srr.getStatus(), InteractionStatus.READ);
+
+        // If we replace the resource with the same value, we should get back the same result
+        assertTrue(srr == srr.replace(patient));
+
+        // Now check we can actually replace the resource with a new value
+        Patient patient2 = patient.toBuilder()
+                .id("patient2")
+                .build();
+
+        SingleResourceResult<Patient> srr2 = srr.replace(patient2);
+        assertFalse(srr2 == srr);
+        assertTrue(srr2.getResource() == patient2);
+    }
+}

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -1401,6 +1401,13 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             // Invoke the 'afterSearch' interceptor methods.
             getInterceptorMgr().fireAfterSearchEvent(event);
 
+            // Interceptors might want to change the response bundle, so make sure pick up the new value.
+            // Protect against an interceptor returning something other than a Bundle
+            Resource afterSearchEventValue = event.getFhirResource();
+            if (afterSearchEventValue.is(Bundle.class)) {
+                bundle = afterSearchEventValue.as(Bundle.class);
+            }
+
             // Commit our transaction if we started one before.
             txn.commit();
             txn = null;

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -1177,6 +1177,9 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             // Invoke the 'afterRead' interceptor methods.
             getInterceptorMgr().fireAfterReadEvent(event);
 
+            // Update the result if the interceptor changed it
+            result = result.replace(event.getFhirResource());
+
             if (result.getResource() == null && throwExcOnNull) {
                 if (result.isDeleted()) {
                     throw new FHIRResourceDeletedException("Resource '" + type + "/" + id + "' is deleted.");
@@ -1246,6 +1249,9 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
             // Invoke the 'afterVread' interceptor methods.
             getInterceptorMgr().fireAfterVreadEvent(event);
+
+            // Update the result if the interceptor changed it
+            srr = srr.replace(event.getFhirResource());
 
             if (srr.getResource() == null) {
                 if (srr.isDeleted()) {
@@ -1318,6 +1324,12 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
             // Invoke the 'afterHistory' interceptor methods.
             getInterceptorMgr().fireAfterHistoryEvent(event);
+
+            // Update the result if the interceptor changed it
+            Resource x = event.getFhirResource();
+            if (x != null && x.is(Bundle.class)) {
+                bundle = x.as(Bundle.class);
+            }
 
             // Commit our transaction if we started one before.
             txn.commit();
@@ -1404,7 +1416,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             // Interceptors might want to change the response bundle, so make sure pick up the new value.
             // Protect against an interceptor returning something other than a Bundle
             Resource afterSearchEventValue = event.getFhirResource();
-            if (afterSearchEventValue.is(Bundle.class)) {
+            if (afterSearchEventValue != null && afterSearchEventValue.is(Bundle.class)) {
                 bundle = afterSearchEventValue.as(Bundle.class);
             }
 
@@ -3315,6 +3327,12 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         // Invoke the 'afterHistory' interceptor methods.
         event.setFhirResource(bundle);
         getInterceptorMgr().fireAfterHistoryEvent(event);
+
+        // See if the interceptor modified the result bundle
+        Resource x = event.getFhirResource();
+        if (x != null && x.is(Bundle.class)) {
+            bundle = x.as(Bundle.class);
+        }
 
         return bundle;
     }

--- a/fhir-server/src/test/java/com/ibm/fhir/server/util/FHIRRestHelperTest.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/util/FHIRRestHelperTest.java
@@ -8,6 +8,8 @@ package com.ibm.fhir.server.util;
 
 import static com.ibm.fhir.model.type.String.string;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
@@ -18,6 +20,7 @@ import static org.testng.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
@@ -61,7 +64,10 @@ import com.ibm.fhir.model.type.code.NarrativeStatus;
 import com.ibm.fhir.model.type.code.ProcedureStatus;
 import com.ibm.fhir.persistence.FHIRPersistence;
 import com.ibm.fhir.persistence.FHIRPersistenceSupport;
+import com.ibm.fhir.persistence.InteractionStatus;
 import com.ibm.fhir.persistence.MultiResourceResult;
+import com.ibm.fhir.persistence.ResourceChangeLogRecord;
+import com.ibm.fhir.persistence.ResourceChangeLogRecord.ChangeType;
 import com.ibm.fhir.persistence.ResourceResult;
 import com.ibm.fhir.persistence.SingleResourceResult;
 import com.ibm.fhir.persistence.context.FHIRPersistenceEvent;
@@ -163,6 +169,113 @@ public class FHIRRestHelperTest {
     }
 
     @Test
+    public void testAfterReadInterceptor() throws Exception {
+        final String testResourceId = UUID.randomUUID().toString();
+        final String afterResourceId = UUID.randomUUID().toString();
+        FHIRPersistenceInterceptor interceptor = new FHIRPersistenceInterceptor() {
+
+            @Override
+            public void afterRead(FHIRPersistenceEvent event) throws FHIRPersistenceInterceptorException {
+                // change the id of the resource (not a good idea in real-life, of course, but easy
+                // to code the test). Only update the resource if it matches the test resource used
+                // in this method...the interceptors are global and cannot be removed.
+                final Resource resourceIn = event.getFhirResource();
+                if (resourceIn != null && resourceIn.getId() != null && resourceIn.getId().equals(testResourceId)) {
+                    final Resource resourceOut = resourceIn.toBuilder().id(afterResourceId).build();
+                    event.setFhirResource(resourceOut);
+                }
+            }
+        };
+        FHIRPersistenceInterceptorMgr.getInstance().addInterceptor(interceptor);
+
+        // Create the search response for our persistence mock
+        Patient patient = Patient.builder()
+            .name(HumanName.builder()
+                .given(string("John"))
+                .family(string("Doe"))
+                .build())
+            .id(testResourceId) // so the interceptor knows it is this test
+            .meta(Meta.builder()
+                .lastUpdated(Instant.now())
+                .versionId(Id.of("1"))
+                .build())
+            .build();
+
+        FHIRPersistence persistence = Mockito.mock(FHIRPersistence.class);
+        SingleResourceResult<Resource> resourceResult = new SingleResourceResult.Builder<>()
+                .resource(patient)
+                .success(true)
+                .interactionStatus(InteractionStatus.READ)
+                .build();
+
+        when(persistence.generateResourceId()).thenReturn("generated-0");
+        when(persistence.getTransaction()).thenReturn(new MockTransactionAdapter());
+        when(persistence.read(any(), any(), any())).thenReturn(resourceResult);
+        FHIRRequestContext.get().setOriginalRequestUri("test");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
+
+        SingleResourceResult<? extends Resource> readResult = helper.doRead("Patient", testResourceId);
+        assertNotNull(readResult);
+        assertNotNull(readResult.getResource());
+        assertNotNull(readResult.getResource().getId());
+        assertEquals(readResult.getResource().getId(), afterResourceId);
+    }
+    
+    @Test
+    public void testAfterVReadInterceptor() throws Exception {
+        final String testResourceId = UUID.randomUUID().toString();
+        final String afterResourceId = UUID.randomUUID().toString();
+        FHIRPersistenceInterceptor interceptor = new FHIRPersistenceInterceptor() {
+
+            @Override
+            public void afterVread(FHIRPersistenceEvent event) throws FHIRPersistenceInterceptorException {
+                // change the id of the resource (not a good idea in real-life, of course, but easy
+                // to code the test). Only update the resource if it matches the test resource used
+                // in this method...the interceptors are global and cannot be removed.
+                assertNotNull(event.getFhirResource());
+                final Resource resourceIn = event.getFhirResource();
+                if (resourceIn != null && resourceIn.getId() != null && resourceIn.getId().equals(testResourceId)) {
+                    final Resource resourceOut = resourceIn.toBuilder().id(afterResourceId).build();
+                    event.setFhirResource(resourceOut);
+                }
+            }
+        };
+        FHIRPersistenceInterceptorMgr.getInstance().addInterceptor(interceptor);
+
+        // Create the search response for our persistence mock
+        Patient patient = Patient.builder()
+            .name(HumanName.builder()
+                .given(string("John"))
+                .family(string("Doe"))
+                .build())
+            .id(testResourceId) // so the interceptor knows it is this test
+            .meta(Meta.builder()
+                .lastUpdated(Instant.now())
+                .versionId(Id.of("1"))
+                .build())
+            .build();
+
+        FHIRPersistence persistence = Mockito.mock(FHIRPersistence.class);
+        SingleResourceResult<Resource> resourceResult = new SingleResourceResult.Builder<>()
+                .resource(patient)
+                .success(true)
+                .interactionStatus(InteractionStatus.READ)
+                .build();
+
+        when(persistence.generateResourceId()).thenReturn("generated-0");
+        when(persistence.getTransaction()).thenReturn(new MockTransactionAdapter());
+        when(persistence.vread(any(), any(), any(), any())).thenReturn(resourceResult);
+        FHIRRequestContext.get().setOriginalRequestUri("test");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
+
+        SingleResourceResult<? extends Resource> readResult = helper.doVRead("Patient", testResourceId, "1");
+        assertNotNull(readResult);
+        assertNotNull(readResult.getResource());
+        assertNotNull(readResult.getResource().getId());
+        assertEquals(readResult.getResource().getId(), afterResourceId);
+    }
+
+    @Test
     public void testAfterSearchInterceptor() throws Exception {
         final String testResourceId = "testAfterSearchInterceptor";
         FHIRPersistenceInterceptor interceptor = new FHIRPersistenceInterceptor() {
@@ -247,19 +360,220 @@ public class FHIRRestHelperTest {
         assertNotNull(searchResponse);
         // Verify that the search result contains both patient 123 and patient 42 (which was
         // injected by the afterSearch interceptor)
-        boolean got123 = false;
+        boolean gotTestResource = false;
         boolean got42 = false;
         for (Bundle.Entry entry: searchResponse.getEntry()) {
             assertNotNull(entry.getResource());
             if (testResourceId.equals(entry.getResource().getId())) {
-                got123 = true;
+                gotTestResource = true;
             }
             if ("42".equals(entry.getResource().getId())) {
                 got42 = true;
             }
         }
-        assertTrue(got123);
+        assertTrue(gotTestResource);
         assertTrue(got42);
+    }
+
+    @Test
+    public void testAfterHistoryInterceptor() throws Exception {
+        final String testResourceId = UUID.randomUUID().toString();
+        final String afterResourceId = UUID.randomUUID().toString();
+        FHIRPersistenceInterceptor interceptor = new FHIRPersistenceInterceptor() {
+
+            @Override
+            public void afterHistory(FHIRPersistenceEvent event) throws FHIRPersistenceInterceptorException {
+                assertNotNull(event.getFhirResource());
+                final Resource historyResult = event.getFhirResource();
+                
+                if (historyResult.is(Bundle.class)) {
+                    Bundle historyResultBundle = historyResult.as(Bundle.class);
+    
+                    // The interceptor is global, so we may get calls from other tests which we should just ignore
+                    boolean foundTarget = false;
+                    for (Bundle.Entry entry: historyResultBundle.getEntry()) {
+                        Resource r = entry.getResource();
+                        if (r != null && testResourceId.equals(r.getId())) {
+                            foundTarget = true;
+                            break;
+                        }
+                    }
+                    
+                    if (foundTarget) {
+                        // Inject a new patient into the bundle and update the event
+                        Patient patient = Patient.builder()
+                                .id(afterResourceId)
+                                .generalPractitioner(Reference.builder()
+                                    .reference(string("Practitioner/42"))
+                                    .build())
+                                .build();
+        
+                        Bundle.Entry.Response patientEntry = Bundle.Entry.Response.builder()
+                                .status("200")
+                                .id("ber42")
+                                .build();
+                        Bundle.Entry bundleEntry = Bundle.Entry.builder()
+                                .resource(patient)
+                                .response(patientEntry)
+                                .build();
+        
+                        historyResultBundle = historyResultBundle.toBuilder()
+                                .entry(bundleEntry).build();
+                        event.setFhirResource(historyResultBundle);
+                    }
+                }
+            }
+        };
+        FHIRPersistenceInterceptorMgr.getInstance().addInterceptor(interceptor);
+
+        // Create the search response for our persistence mock
+        Patient patient = Patient.builder()
+            .name(HumanName.builder()
+                .given(string("John"))
+                .family(string("Doe"))
+                .build())
+            .id(testResourceId) // so the interceptor knows it is this test
+            .meta(Meta.builder()
+                .lastUpdated(Instant.now())
+                .versionId(Id.of("1"))
+                .build())
+            .build();
+
+        MultiResourceResult historyResult = MultiResourceResult.builder()
+                .resourceResult(ResourceResult.from(patient))
+                .success(true)
+                .build();
+        FHIRPersistence persistence = Mockito.mock(FHIRPersistence.class);
+        @SuppressWarnings("unchecked")
+        SingleResourceResult<Resource> mockResult = Mockito.mock(SingleResourceResult.class);
+        when(mockResult.getResource()).thenReturn(patient);
+
+        when(persistence.generateResourceId()).thenReturn("generated-0");
+        when(persistence.getTransaction()).thenReturn(new MockTransactionAdapter());
+        when(persistence.read(any(), any(), any())).thenReturn(mockResult);
+        when(persistence.history(any(), any(), any())).thenReturn(historyResult);
+        FHIRRequestContext.get().setOriginalRequestUri("test");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
+
+        // Call doSearch
+        MultivaluedMap<String, String> queryParameters = new MultivaluedHashMap<>();
+        Bundle historyResponse = helper.doHistory("Patient", testResourceId, queryParameters, "test");
+        assertNotNull(historyResponse);
+        // Verify that the history result contains both original and injected patient resources
+        boolean gotTestResource = false;
+        boolean gotAfter = false;
+        for (Bundle.Entry entry: historyResponse.getEntry()) {
+            assertNotNull(entry.getResource());
+            if (testResourceId.equals(entry.getResource().getId())) {
+                gotTestResource = true;
+            }
+            if (afterResourceId.equals(entry.getResource().getId())) {
+                gotAfter = true;
+            }
+        }
+        assertTrue(gotTestResource);
+        assertTrue(gotAfter);
+    }
+
+    @Test
+    public void testAfterSystemHistoryInterceptor() throws Exception {
+        final String testResourceId = UUID.randomUUID().toString();
+        final String afterResourceId = UUID.randomUUID().toString();
+        FHIRPersistenceInterceptor interceptor = new FHIRPersistenceInterceptor() {
+
+            @Override
+            public void afterHistory(FHIRPersistenceEvent event) throws FHIRPersistenceInterceptorException {
+                assertNotNull(event.getFhirResource());
+                final Resource historyResult = event.getFhirResource();
+                
+                if (historyResult.is(Bundle.class)) {
+                    Bundle historyResultBundle = historyResult.as(Bundle.class);
+    
+                    // The interceptor is global, so we may get calls from other tests which we should just ignore
+                    boolean foundTarget = false;
+                    for (Bundle.Entry entry: historyResultBundle.getEntry()) {
+                        Resource r = entry.getResource();
+                        if (r != null && testResourceId.equals(r.getId())) {
+                            foundTarget = true;
+                            break;
+                        }
+                    }
+                    
+                    if (foundTarget) {
+                        // Inject a new patient into the bundle and update the event
+                        Patient patient = Patient.builder()
+                                .id(afterResourceId)
+                                .generalPractitioner(Reference.builder()
+                                    .reference(string("Practitioner/42"))
+                                    .build())
+                                .build();
+        
+                        Bundle.Entry.Response patientEntry = Bundle.Entry.Response.builder()
+                                .status("200")
+                                .id("ber42")
+                                .build();
+                        Bundle.Entry bundleEntry = Bundle.Entry.builder()
+                                .resource(patient)
+                                .response(patientEntry)
+                                .build();
+        
+                        historyResultBundle = historyResultBundle.toBuilder()
+                                .entry(bundleEntry).build();
+                        event.setFhirResource(historyResultBundle);
+                    }
+                }
+            }
+        };
+        FHIRPersistenceInterceptorMgr.getInstance().addInterceptor(interceptor);
+
+        // Create the search response for our persistence mock
+        Patient patient = Patient.builder()
+            .name(HumanName.builder()
+                .given(string("John"))
+                .family(string("Doe"))
+                .build())
+            .id(testResourceId) // so the interceptor knows it is this test
+            .meta(Meta.builder()
+                .lastUpdated(Instant.now())
+                .versionId(Id.of("1"))
+                .build())
+            .build();
+
+        FHIRPersistence persistence = Mockito.mock(FHIRPersistence.class);
+        @SuppressWarnings("unchecked")
+        SingleResourceResult<Resource> mockResult = Mockito.mock(SingleResourceResult.class);
+        when(mockResult.getResource()).thenReturn(patient);
+
+        List<ResourceChangeLogRecord> changesResult = new ArrayList<>();
+        changesResult.add(new ResourceChangeLogRecord("Patient", testResourceId, 1, 1L, java.time.Instant.now(), ChangeType.CREATE));
+        List<Resource> resourceList = new ArrayList<>();
+        resourceList.add(patient);
+        when(persistence.generateResourceId()).thenReturn("generated-0");
+        when(persistence.getTransaction()).thenReturn(new MockTransactionAdapter());
+        when(persistence.readResourcesForRecords(any())).thenReturn(resourceList);
+        when(persistence.changes(any(), anyInt(), any(), any(), any(), any(), anyBoolean(), any())).thenReturn(changesResult);
+        FHIRRequestContext.get().setOriginalRequestUri("https://fhir.example.com/r4/_history");
+        FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
+
+        // Call system level history
+        MultivaluedMap<String, String> queryParameters = new MultivaluedHashMap<>();
+        Bundle historyResponse = helper.doHistory(queryParameters, "test", null);
+        assertNotNull(historyResponse);
+        // Verify that the history result contains both original and injected patient resources
+        boolean gotTestResource = false;
+        boolean gotAfter = false;
+        for (Bundle.Entry entry: historyResponse.getEntry()) {
+            assertNotNull(entry.getResource());
+            if (testResourceId.equals(entry.getResource().getId())) {
+                gotTestResource = true;
+            }
+            if (afterResourceId.equals(entry.getResource().getId())) {
+                gotAfter = true;
+            }
+        }
+        assertTrue(gotTestResource);
+        assertTrue(gotAfter);
     }
 
     /**
@@ -2163,13 +2477,17 @@ public class FHIRRestHelperTest {
             .build();
 
         FHIRPersistence persistence = Mockito.mock(FHIRPersistence.class);
-        @SuppressWarnings("unchecked")
-        SingleResourceResult<Resource> mockResult = Mockito.mock(SingleResourceResult.class);
-        when(mockResult.getResource()).thenReturn(patient);
 
+        // Need to use a real SingleResourceResult, not a mock one
+        SingleResourceResult<Resource> resourceResult = new SingleResourceResult.Builder<>()
+            .resource(patient)
+            .success(true)
+            .interactionStatus(InteractionStatus.READ)
+            .build();
+        
         when(persistence.generateResourceId()).thenReturn("generated-0");
         when(persistence.getTransaction()).thenReturn(new MockTransactionAdapter());
-        when(persistence.read(any(), any(), any())).thenReturn(mockResult);
+        when(persistence.read(any(), any(), any())).thenReturn(resourceResult);
         FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Call doDelete, the interceptor will check if the events are set
@@ -2181,20 +2499,21 @@ public class FHIRRestHelperTest {
      */
     @Test
     public void testDeleteDeleted() throws Exception {
-
-
-        // Mock up the result that the persistence layer will return from its read call
-        @SuppressWarnings("unchecked")
-        SingleResourceResult<Resource> mockResult = Mockito.mock(SingleResourceResult.class);
-        when(mockResult.getResource()).thenReturn(null);
-        when(mockResult.getVersion()).thenReturn(2);
-        when(mockResult.isDeleted()).thenReturn(true);
-
+        // Make sure we're using a real resource, not a mocked one so that replace works correctly
+        // when it is called inside FHIRRestHelper#doRead
+        SingleResourceResult<Resource> resourceResult = new SingleResourceResult.Builder<>()
+                .deleted(true)
+                .version(2)
+                .success(true)
+                .interactionStatus(InteractionStatus.READ)
+                .build()
+                ;
+        
         // Mock up the persistence impl
         FHIRPersistence persistence = Mockito.mock(FHIRPersistence.class);
         when(persistence.generateResourceId()).thenReturn("generated-0");
         when(persistence.getTransaction()).thenReturn(new MockTransactionAdapter());
-        when(persistence.read(any(), any(), any())).thenReturn(mockResult);
+        when(persistence.read(any(), any(), any())).thenReturn(resourceResult);
         FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Call doDelete, check that the response contains the version of the deleted resource
@@ -2255,16 +2574,17 @@ public class FHIRRestHelperTest {
                 .build();
 
         FHIRPersistence persistence = Mockito.mock(FHIRPersistence.class);
-        @SuppressWarnings("unchecked")
-        SingleResourceResult<Resource> mockResult = Mockito.mock(SingleResourceResult.class);
-        when(mockResult.getResource()).thenReturn(patientWithId);
+        SingleResourceResult<Resource> resourceResult = new SingleResourceResult.Builder<>()
+            .resource(patientWithId)
+            .success(true)
+            .interactionStatus(InteractionStatus.READ)
+            .build();
 
         when(persistence.generateResourceId()).thenReturn("generated-0");
         when(persistence.getTransaction()).thenReturn(new MockTransactionAdapter());
-        when(persistence.read(any(), any(), any())).thenReturn(mockResult);
-        // when(persistence.create(any(), any())).thenReturn(mockResult);
-        when(persistence.create(any(), any())).thenReturn(mockResult);
-        when(persistence.update(any(), any())).thenReturn(mockResult);
+        when(persistence.read(any(), any(), any())).thenReturn(resourceResult);
+        when(persistence.create(any(), any())).thenReturn(resourceResult);
+        when(persistence.update(any(), any())).thenReturn(resourceResult);
         FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // The helper must pass the resource updated by the interceptor to the persistence#create method


### PR DESCRIPTION
Signed-off-by: Robin Arnold <robin.arnold@ibm.com>

Allows persistence interceptors to modify the resource when processing the following events:

- afterRead
- afterVread
- afterSearch
- afterHistory

Currently the interceptor is trusted to not do anything which would invalidate the resource for the given interaction.
