### PR TITLE
issue #3304 - favor Exceptions over Errors in ExampleRequestProcessor

### DIFF
--- a/fhir-model/src/test/java/com/ibm/fhir/model/spec/test/DriverMetrics.java
+++ b/fhir-model/src/test/java/com/ibm/fhir/model/spec/test/DriverMetrics.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,22 +8,22 @@ package com.ibm.fhir.model.spec.test;
 
 /**
  * Used to collect response time metrics during development
- * (e.h. test-case runs) to identify hotspots or concurrency issues. 
+ * (e.g. test-case runs) to identify hotspots or concurrency issues.
  * Not intended for runtime instrumentation.
  */
 public class DriverMetrics {
     // Number of nanoseconds in a second
     public static final double NANOS = 1e9;
-    
+
     // Number of nanoseconds in a millisecond
     public static final long NANOS_MS = 1000000L;
-    
+
     // collection of read time samples
     private final ResponseTimes readTimes = new ResponseTimes();
-    
+
     // collection of validation time samples
     private final ResponseTimes validateTimes = new ResponseTimes();
-    
+
     // collection of process time samples
     private final ResponseTimes processTimes = new ResponseTimes();
 
@@ -72,7 +72,7 @@ public class DriverMetrics {
     public void addGetTime(long ms) {
         this.getTimes.addSample(ms);
     }
-    
+
     /**
      * Render a report using the given DriverStats report generator
      * @return

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/examples/ExampleRequestProcessor.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/examples/ExampleRequestProcessor.java
@@ -1,12 +1,10 @@
 /*
- * (C) Copyright IBM Corp. 2019, 2020
+ * (C) Copyright IBM Corp. 2019, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package com.ibm.fhir.server.test.examples;
-
-import static org.testng.Assert.assertEquals;
 
 import java.util.logging.Logger;
 
@@ -28,7 +26,7 @@ import com.ibm.fhir.server.test.FHIRServerTestBase;
  * Exercises the FHIR REST API. Create is called for each resource, then the
  * resource is retrieved with a GET and its fingerprint is compared with the
  * original to verify its integrity.
- * 
+ *
  * Fingerprinting is used for the comparison because the FHIR server adds
  * additional (meta) content, which is ignored when the fingerprint is
  * computed.
@@ -45,10 +43,10 @@ public class ExampleRequestProcessor implements IExampleProcessor {
 
     // Read (GET) multiplier for more interesting (simple) performance checks.
     private final int readIterations;
-    
+
     // Target (once configured) can be shared amongst threads
     private final WebTarget target;
-    
+
     /**
      * Public constructor
      * @param base
@@ -66,35 +64,31 @@ public class ExampleRequestProcessor implements IExampleProcessor {
 
     @Override
     public void process(String jsonFile, Resource resource) throws Exception {
-        
+        String resourceTypeName = resource.getClass().getSimpleName();
+
         // clear the id value from the example so we can assign our own
         resource = resource.toBuilder().id(null).build();
-        
+
         // Compute a fingerprint which can be used to check the consistency of the
         // resource we read back from FHIR
         ResourceFingerprintVisitor v = new ResourceFingerprintVisitor();
-        resource.accept(resource.getClass().getSimpleName(), v);
-
-        String resourceTypeName = resource.getClass().getSimpleName();
+        resource.accept(resourceTypeName, v);
+        SaltHash baseline = v.getSaltAndHash();
 
         // Build a new resource and then call the 'create' API.
         long postStart = System.nanoTime();
         Entity<Resource> entity = Entity.entity(resource, FHIRMediaType.APPLICATION_FHIR_JSON);
-        Response response = target.path(resourceTypeName).request().header(FHIRConfiguration.DEFAULT_TENANT_ID_HEADER_NAME, tenantId).post(entity, Response.class);
-        
+        Response response = target.path(resourceTypeName).request()
+                .header(FHIRConfiguration.DEFAULT_TENANT_ID_HEADER_NAME, tenantId)
+                .post(entity, Response.class);
+
         try {
             base.assertResponse(response, Response.Status.CREATED.getStatusCode());
-            
-            // FHIR server now sends back OperationOutcome info in some places. We need to consume this
-            // to avoid the FHIR server complaining about broken pipe if we close the connection while
-            // it is trying to still write the JSON.
-            response.readEntity(String.class);
         } catch (AssertionError x) {
             // definitely not what we were expecting, so log what the FHIR server gave us
             String msg = response.readEntity(String.class);
-            logger.warning("Unexpected response for JSON file: " + jsonFile);
             logger.warning("Response body: " + msg);
-            throw x;
+            throw new Exception("Unexpected response for JSON file: " + jsonFile, x);
         }
         long postEnd = System.nanoTime();
         metrics.addPostTime((postEnd - postStart) / DriverMetrics.NANOS_MS);
@@ -106,7 +100,10 @@ public class ExampleRequestProcessor implements IExampleProcessor {
         // can repeat this a number of times to help get some more useful performance numbers
         for (int i=0; i<this.readIterations; i++) {
             postEnd = System.nanoTime(); // update for each iteration
-            response = target.path(resourceTypeName + "/" + logicalId).request(FHIRMediaType.APPLICATION_FHIR_JSON).header(FHIRConfiguration.DEFAULT_TENANT_ID_HEADER_NAME, tenantId).get();
+            response = target.path(resourceTypeName + "/" + logicalId)
+                    .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                    .header(FHIRConfiguration.DEFAULT_TENANT_ID_HEADER_NAME, tenantId)
+                    .get();
             base.assertResponse(response, Response.Status.OK.getStatusCode());
             metrics.addGetTime((System.nanoTime() - postEnd) / DriverMetrics.NANOS_MS);
         }
@@ -116,25 +113,23 @@ public class ExampleRequestProcessor implements IExampleProcessor {
 
         // Now we can check what we sent equals what we got back (minus the meta changes)
         // making sure to seed the visitor with the same salt we used above
-        SaltHash baseline = v.getSaltAndHash();
         ResourceFingerprintVisitor v2 = new ResourceFingerprintVisitor(baseline);
         responseResource.accept(responseResource.getClass().getSimpleName(), v2);
-
         SaltHash responseHash = v2.getSaltAndHash();
-        
+
         if (!responseHash.equals(baseline)) {
             // Use the ResourceComparatorVisitor to provide some detail about what's different
             ResourceComparatorVisitor originals = new ResourceComparatorVisitor();
             resource.accept(resource.getClass().getSimpleName(), originals);
-            
+
             ResourceComparatorVisitor others = new ResourceComparatorVisitor();
             responseResource.accept(responseResource.getClass().getSimpleName(), others);
-            
+
             // Perform a bi-directional comparison of values in the maps
             ResourceComparatorVisitor.compare(originals.getValues(), others.getValues());
 
             // throw the error so it is handled by the test framework
-            assertEquals(responseHash, baseline);
+            throw new Exception("The retrieved resource does not match the expected resource.");
         }
     }
 }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/examples/ExampleRequestProcessor.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/examples/ExampleRequestProcessor.java
@@ -77,7 +77,8 @@ public class ExampleRequestProcessor implements IExampleProcessor {
 
         // Build a new resource and then call the 'create' API.
         long postStart = System.nanoTime();
-        Entity<Resource> entity = Entity.entity(resource, FHIRMediaType.APPLICATION_FHIR_JSON);
+        // Explicitly use fhirVersion 4.3 so that we can use all the R4B resource types
+        Entity<Resource> entity = Entity.entity(resource, FHIRMediaType.APPLICATION_FHIR_43_JSON_TYPE);
         Response response = target.path(resourceTypeName).request()
                 .header(FHIRConfiguration.DEFAULT_TENANT_ID_HEADER_NAME, tenantId)
                 .post(entity, Response.class);

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/examples/R4ExampleServerTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/examples/R4ExampleServerTest.java
@@ -1,5 +1,5 @@
-/**
- * (C) Copyright IBM Corp. 2019, 2021
+/*
+ * (C) Copyright IBM Corp. 2019, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -23,7 +23,7 @@ import com.ibm.fhir.validation.test.ValidationProcessor;
  * Basic sniff test of the FHIR Server.
  */
 public class R4ExampleServerTest extends FHIRServerTestBase {
-    
+
     // the tenant id to use for the FHIR server requests
     private String tenantId;
 
@@ -39,7 +39,6 @@ public class R4ExampleServerTest extends FHIRServerTestBase {
         // Setup a Pool
         ExecutorService es = Executors.newFixedThreadPool(5);
         driver.setPool(es, 5);
-        
 
         DriverMetrics dm = new DriverMetrics();
         driver.setMetrics(dm);


### PR DESCRIPTION
The method signature indicates that Exception is thrown, but the
implementation was throwing AssertionErrors instead.
This lead us to miss these in our exception handling and, since they
were within an ExecutorPool, it never got bubbled up to the test thread.

After this change, 3 examples from our MINIMAL set were failing due to 
the server defaulting to fhirVersion 4.0 and so we now explicitly set the 
fhirVersion to 4.3 in ExampleRequestProcessor.

I made some other minor changes (mostly style preference stuff) along
the way and included those in the commit.

Signed-off-by: Lee Surprenant <lmsurpre@merative.com>