### PR TITLE
issue #3874 - use legacy export when payload offloading is configured

### DIFF
--- a/fhir-bulkdata-webapp/pom.xml
+++ b/fhir-bulkdata-webapp/pom.xml
@@ -94,6 +94,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>fhir-persistence-blob</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>fhir-validation</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/fhir-config/src/main/java/org/linuxforhealth/fhir/config/FHIRConfigHelper.java
+++ b/fhir-config/src/main/java/org/linuxforhealth/fhir/config/FHIRConfigHelper.java
@@ -104,8 +104,8 @@ public class FHIRConfigHelper {
     }
 
     /**
-     * This generic function will perform the work of retrieving a property from either the tenant-specific config, or
-     * the default config, and then converting the resulting value to the appropriate type.
+     * This generic function will perform the work of retrieving a property from either the tenant-specific
+     * config or the default config, and then converting the resulting value to the appropriate type.
      *
      * @param propertyName
      *            the name of the property to retrieve
@@ -139,19 +139,19 @@ public class FHIRConfigHelper {
                             } else if (Double.class.equals(expectedDataType)) {
                                 result = (T) Double.valueOf((String) obj);
                             } else {
-                                throw new RuntimeException("Expected property " + propertyName + " to be of type " + expectedDataType.getName() + ", but was of type "
-                                        + obj.getClass().getName());
+                                throw new RuntimeException("Expected property " + propertyName + " to be of type "
+                                        + expectedDataType.getName() + ", but was of type " + obj.getClass().getName());
                             }
                         } else if (obj instanceof Boolean) {
                             if (String.class.equals(expectedDataType)) {
                                 result = (T) ((Boolean)obj).toString();
                             } else {
-                                throw new RuntimeException("Expected property " + propertyName + " to be of type " + expectedDataType.getName() + ", but was of type "
-                                        + obj.getClass().getName());
+                                throw new RuntimeException("Expected property " + propertyName + " to be of type "
+                                        + expectedDataType.getName() + ", but was of type " + obj.getClass().getName());
                             }
                         } else {
-                            throw new RuntimeException("Expected property " + propertyName + " to be of type " + expectedDataType.getName() + ", but was of type "
-                                    + obj.getClass().getName());
+                            throw new RuntimeException("Expected property " + propertyName + " to be of type "
+                                    + expectedDataType.getName() + ", but was of type " + obj.getClass().getName());
                         }
                     }
                 }

--- a/operation/fhir-operation-bulkdata/src/main/java/org/linuxforhealth/fhir/operation/bulkdata/config/impl/V2ConfigurationImpl.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/org/linuxforhealth/fhir/operation/bulkdata/config/impl/V2ConfigurationImpl.java
@@ -12,9 +12,11 @@ import java.util.List;
 import org.linuxforhealth.fhir.config.FHIRConfigHelper;
 
 /**
- * Starting with 4.6
+ * Starting with FHIR Server version 4.6
  */
 public class V2ConfigurationImpl extends AbstractSystemConfigurationImpl {
+    // the new FHIRPersistenceJDBCBlob implementation is not compatible with fast-export, so we need to watch for that
+    private static final String BLOB_PERSISTENCE_FACTORY = "org.linuxforhealth.fhir.persistence.blob.FHIRPersistenceJDBCBlobFactory";
 
     @Override
     public boolean legacy() {
@@ -164,8 +166,9 @@ public class V2ConfigurationImpl extends AbstractSystemConfigurationImpl {
 
     @Override
     public boolean isFastExport() {
+        String persistenceFactoryClassname = FHIRConfigHelper.getStringProperty("fhirServer/persistence/factoryClassname", "");
         String type = FHIRConfigHelper.getStringProperty("fhirServer/bulkdata/core/systemExportImpl", "fast");
-        return "fast".equals(type);
+        return !BLOB_PERSISTENCE_FACTORY.equals(persistenceFactoryClassname) && "fast".equals(type);
     }
 
     @Override


### PR DESCRIPTION
A cleaner approach would be to add a method to FHIRPersistence so that
implementations can indicate whether they support fetchResourcePayloads
which is what we use for the fast export. Then we could pass that into
BulkDataClient.submitExport where we decide which export implementation
to use.

However, ideally we'd just add this support...then we probably wouldn't
need those changes.

Therefor, for now, I opted for the quick and dirty fix.

Signed-off-by: Lee Surprenant <lmsurpre@merative.com>