### PR TITLE
issue #3256 added unit tests to support QA of FHIRClient default mime…

### DIFF
--- a/fhir-server-test/src/test/resources/testdata/Ingredient-1.json
+++ b/fhir-server-test/src/test/resources/testdata/Ingredient-1.json
@@ -1,0 +1,40 @@
+{
+    "resourceType": "Ingredient",
+    "meta": {
+        "tag": [
+            {
+                "code": "ibm/minimal"
+            }
+        ]
+    },
+    "_status": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode": "unknown"
+            }
+        ]
+    },
+    "role": {
+        "coding": [
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                        "valueCode": "unknown"
+                    }
+                ]
+            }
+        ]
+    },
+    "substance": {
+        "code": {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                    "valueCode": "unknown"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
…type

The two new unit tests check:
1. Using the default FHIRClient configuration, interactions related to an R4B resource type (Ingredient) are successful.
2. When overriding the mime type property to remove fhirVersion, interactions related to an R4B resource type are unsuccessful.
 
Signed-off-by: Robin Arnold <robin.arnold@ibm.com>