### PR TITLE
issue #3888 - work around timestamp-related issues in test environment

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Checkout source code
       uses: actions/checkout@v2.3.3
     - name: Set up java
-      uses: actions/setup-java@v2.3.1
+      uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.3
     - name: Setup java
-      uses: actions/setup-java@v2.3.1
+      uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
@@ -43,7 +43,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.3
     - name: Setup java
-      uses: actions/setup-java@v2.3.1
+      uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
@@ -127,7 +127,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.3
     - name: Setup java
-      uses: actions/setup-java@v2.3.1
+      uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.3
     - name: Set up java
-      uses: actions/setup-java@v2.3.1
+      uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}

--- a/.github/workflows/javadocs.yml
+++ b/.github/workflows/javadocs.yml
@@ -33,7 +33,7 @@ jobs:
             path: gh-pages
             token: ${{ secrets.DOCS_SITE_TOKEN }}
     - name: Set up java
-      uses: actions/setup-java@v2.3.1
+      uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}

--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -61,7 +61,7 @@ jobs:
           git fetch --no-tags --prune --depth=1 origin +refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}
 
       - name: Set up java
-        uses: actions/setup-java@v2.3.1
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Checkout source code
       uses: actions/checkout@v2.3.3
     - name: Setup java
-      uses: actions/setup-java@v2.3.1
+      uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}

--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Checkout source code
       uses: actions/checkout@v2.3.3
     - name: Set up java
-      uses: actions/setup-java@v2.3.1
+      uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         ref: refs/tags/${{ matrix.tag }}
     - name: Setup java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}

--- a/.github/workflows/reindex.yml
+++ b/.github/workflows/reindex.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Checkout source code
       uses: actions/checkout@v2.3.4
     - name: Set up java
-      uses: actions/setup-java@v2.3.1
+      uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: '11'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         ref: refs/heads/main
         fetch-depth: 1
     - name: Setup java
-      uses: actions/setup-java@v2.3.1
+      uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Checkout source code
       uses: actions/checkout@v2.3.3
     - name: Setup java
-      uses: actions/setup-java@v2.3.1
+      uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.3
     - name: Setup java
-      uses: actions/setup-java@v2.3.1
+      uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}

--- a/fhir-persistence-jdbc/src/test/java/org/linuxforhealth/fhir/persistence/jdbc/test/JDBCSortTest.java
+++ b/fhir-persistence-jdbc/src/test/java/org/linuxforhealth/fhir/persistence/jdbc/test/JDBCSortTest.java
@@ -7,7 +7,6 @@
 package org.linuxforhealth.fhir.persistence.jdbc.test;
 
 import org.linuxforhealth.fhir.config.FHIRConfigProvider;
-import org.linuxforhealth.fhir.config.FHIRConfigProvider;
 import org.linuxforhealth.fhir.persistence.FHIRPersistence;
 import org.linuxforhealth.fhir.persistence.jdbc.test.util.PersistenceTestSupport;
 import org.linuxforhealth.fhir.persistence.test.common.AbstractSortTest;

--- a/fhir-persistence/src/test/java/org/linuxforhealth/fhir/persistence/search/test/AbstractWholeSystemSearchTest.java
+++ b/fhir-persistence/src/test/java/org/linuxforhealth/fhir/persistence/search/test/AbstractWholeSystemSearchTest.java
@@ -114,7 +114,10 @@ public abstract class AbstractWholeSystemSearchTest extends AbstractPLSearchTest
                 runQueryTest(Resource.class, "_lastUpdated",
                         savedResource.getMeta().getLastUpdated().getValue().toString());
         assertNotNull(resources);
-        assertEquals(resources.size(), 1, "Number of resources returned");
+        // We might get more than one, but each match should have the same lastUpdated time
+        for (Resource resource : resources) {
+            assertEquals(resource.getMeta().getLastUpdated(), savedResource.getMeta().getLastUpdated());
+        }
         assertTrue(isResourceInResponse(savedResource, resources), "Expected resource not found in the response");
     }
 

--- a/fhir-persistence/src/test/java/org/linuxforhealth/fhir/persistence/test/common/AbstractSortTest.java
+++ b/fhir-persistence/src/test/java/org/linuxforhealth/fhir/persistence/test/common/AbstractSortTest.java
@@ -51,7 +51,7 @@ import org.linuxforhealth.fhir.search.exception.FHIRSearchException;
  *
  */
 public abstract class AbstractSortTest extends AbstractPersistenceTest {
-    boolean DEBUG = true;
+    boolean DEBUG = false;
 
     Basic resource1a;
     Basic resource2a;

--- a/term/fhir-term-graph-loader/src/test/java/org/linuxforhealth/fhir/term/graph/test/GraphTermServiceProviderTimeLimitTest.java
+++ b/term/fhir-term-graph-loader/src/test/java/org/linuxforhealth/fhir/term/graph/test/GraphTermServiceProviderTimeLimitTest.java
@@ -6,7 +6,10 @@
 
 package org.linuxforhealth.fhir.term.graph.test;
 
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
+
+import java.util.Set;
 
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
@@ -15,6 +18,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import org.linuxforhealth.fhir.model.resource.CodeSystem;
+import org.linuxforhealth.fhir.model.resource.CodeSystem.Concept;
 import org.linuxforhealth.fhir.term.graph.FHIRTermGraph;
 import org.linuxforhealth.fhir.term.graph.factory.FHIRTermGraphFactory;
 import org.linuxforhealth.fhir.term.graph.loader.FHIRTermGraphLoader;
@@ -40,9 +44,10 @@ public class GraphTermServiceProviderTimeLimitTest {
 
             FHIRTermServiceProvider provider = new GraphTermServiceProvider(graph, 1);
 
-            provider.getConcepts(codeSystem);
+            Set<Concept> concepts = provider.getConcepts(codeSystem);
+            assertTrue(concepts.size() > 0, "If we get a response, the returned concepts should be non-empty");
 
-            fail();
+            fail("We expected the query to time out but it didn't.");
         } catch (Exception e) {
             Assert.assertTrue(e instanceof FHIRTermServiceException);
             Assert.assertEquals(e.getMessage(), "Graph traversal timed out");

--- a/term/fhir-term-graph/src/main/java/org/linuxforhealth/fhir/term/graph/provider/GraphTermServiceProvider.java
+++ b/term/fhir-term-graph/src/main/java/org/linuxforhealth/fhir/term/graph/provider/GraphTermServiceProvider.java
@@ -71,23 +71,37 @@ public class GraphTermServiceProvider extends AbstractTermServiceProvider {
     private final FHIRTermGraph graph;
     private final int timeLimit;
 
+    /**
+     * @param configuration
+     */
     public GraphTermServiceProvider(Configuration configuration) {
         requireNonNull(configuration, "configuration");
         graph = FHIRTermGraphFactory.open(configuration);
         timeLimit = DEFAULT_TIME_LIMIT;
     }
 
+    /**
+     * @param configuration
+     * @param timeLimit the default time to wait for queries to complete (in milliseconds)
+     */
     public GraphTermServiceProvider(Configuration configuration, int timeLimit) {
         requireNonNull(configuration, "configuration");
         graph = FHIRTermGraphFactory.open(configuration);
         this.timeLimit = timeLimit;
     }
 
+    /**
+     * @param graph
+     */
     public GraphTermServiceProvider(FHIRTermGraph graph) {
         this.graph = requireNonNull(graph, "graph");
         timeLimit = DEFAULT_TIME_LIMIT;
     }
 
+    /**
+     * @param graph
+     * @param timeLimit the default time to wait for queries to complete (in milliseconds)
+     */
     public GraphTermServiceProvider(FHIRTermGraph graph, int timeLimit) {
         this.graph = requireNonNull(graph, "graph");
         this.timeLimit = timeLimit;


### PR DESCRIPTION
There must have been some environmental change to the github actions windows-2019 environment because today a couple tests started failing due to multiple resources being assigned the same timestamp (`Instant.now()` truncated to nearest microsecond).

JDBCSortTest creates 6 resources in a row and in this environment (and only this environment) a number of them were assigned the same lastUpdated time.  To address the issue, I added a 10ms pause between the creates.  I also kept some of the logging statements that I added to AbstractSortTest in case we need to further debug.

JDBCWholeSystemSearchTest was failing for a similar reason...one of the test cases searched by lastUpdated time and was expecting a single match (but was getting 2). I fixed it by checking the lastUpdated time in each response instead of just checking the count.

I'm not sure whether/how it is related but GraphTermServiceProviderTimeLimitTest began failing intermittently as well.
For this one, I'm not sure of the root cause...all I did is assign the result of the call to a variable and add an assert to hopefully get a better error message. We'll need to monitor it.  If it continues failing intermittently, we should probably just skip it (its already marked as "experimental" and its not worth chasing down the root cause at this time).
    
Signed-off-by: Lee Surprenant <lmsurpre@merative.com>