### PR TITLE
use GITHUB_TOKEN and set permissions

### DIFF
--- a/.github/workflows/javadocs.yml
+++ b/.github/workflows/javadocs.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
         - '*'
+  # allows the workflow to be manually executed any time
+  workflow_dispatch:
+
+permissions:
+  pages: write
+  contents: write
 
 jobs:
   build:
@@ -24,14 +30,14 @@ jobs:
             ref: refs/heads/main
             fetch-depth: 1
             path: fhir
-            token: ${{ secrets.DOCS_SITE_TOKEN }}
+            token: ${{ secrets.GITHUB_TOKEN }}
     - name: Grab the GH-Pages Branch
       uses: actions/checkout@v2.3.3
       with:
             ref: refs/heads/gh-pages
             fetch-depth: 1
             path: gh-pages
-            token: ${{ secrets.DOCS_SITE_TOKEN }}
+            token: ${{ secrets.GITHUB_TOKEN }}
     - name: Set up java
       uses: actions/setup-java@v3
       with:
@@ -53,9 +59,7 @@ jobs:
             cp -R fhir-parent/target/site/apidocs ../apidocs/
     - name: Commit and Add GH-Pages
       env:
-            GITHUB_TOKEN: ${{ secrets.DOCS_SITE_TOKEN }}
-            GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
-            GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             CI: true
       run: |
             cd gh-pages
@@ -88,9 +92,7 @@ jobs:
             git commit -m "Automated gh-pages deployment of javadocs: $(date -u)"
     - name: Push changes to GH Pages
       env:
-            GITHUB_TOKEN: ${{ secrets.DOCS_SITE_TOKEN }}
-            GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
-            GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             CI: true
       run: |
             echo "Pushing Changes to gh-pages"
@@ -100,9 +102,7 @@ jobs:
             git push "${remote_repo}" HEAD:gh-pages
     - name: Request GitHub Pages Build
       env:
-            GITHUB_TOKEN: ${{ secrets.DOCS_SITE_TOKEN }}
-            GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
-            GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
             # As documented here, the GH-Pages behavior changed, and the API must be 'Triggered'
             # https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/m-p/43192/highlight/true#M5281

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -8,6 +8,9 @@ on:
   # allows the workflow to be manually executed any time
   workflow_dispatch:
 
+permissions:
+  packages: write
+
 jobs:
   image-refresh:
     runs-on: ubuntu-latest
@@ -29,9 +32,7 @@ jobs:
     - name: Build and Release
       env:
         BASE: origin/${{ github['base_ref'] }}
-        GITHUB_TOKEN: ${{ secrets.DOCS_SITE_TOKEN }}
-        GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
-        GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
     - '.github/workflows/site.yml'
     - '.github/workflows/javadocs.yml'
 
+permissions:
+  packages: write
+
 jobs:
   release-on-push:
     runs-on: ubuntu-latest
@@ -38,9 +41,7 @@ jobs:
     - name: Build and Release
       env:
         BASE: origin/${{ github['base_ref'] }}
-        GITHUB_TOKEN: ${{ secrets.DOCS_SITE_TOKEN }}
-        GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
-        GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         GPG_KEYNAME: ${{ secrets.GPG_KEYNAME }}
         GPG_KEY_FILE: ${{ secrets.GPG_KEY_FILE }}

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -6,6 +6,12 @@ on:
         - "docs/**"
     branches:
         - main
+  # allows the workflow to be manually executed any time
+  workflow_dispatch:
+
+permissions:
+  pages: write
+  contents: write
 
 jobs:
   build:
@@ -23,12 +29,8 @@ jobs:
             ref: refs/heads/main
             fetch-depth: 1
             token: ${{ secrets.GITHUB_TOKEN }}
-      env:
-            GITHUB_TOKEN: ${{ secrets.DOCS_SITE_TOKEN }}
     - name: Grab the GH Pages Branch
       uses: actions/checkout@v2.3.3
-      env:
-            GITHUB_TOKEN: ${{ secrets.DOCS_SITE_TOKEN }}
       with:
             path: gh-pages
             ref: refs/heads/gh-pages
@@ -79,9 +81,7 @@ jobs:
             popd
     - name: Commit and Add GH Pages
       env:
-            GITHUB_TOKEN: ${{ secrets.DOCS_SITE_TOKEN }}
-            GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
-            GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             CI: true
       run: |
             cd gh-pages
@@ -111,9 +111,7 @@ jobs:
             git commit -m "Automated gh-pages deployment: $(date -u)"
     - name: Push changes to GH Pages
       env:
-            GITHUB_TOKEN: ${{ secrets.DOCS_SITE_TOKEN }}
-            GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
-            GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             CI: true
       run: |
             cd gh-pages
@@ -123,9 +121,7 @@ jobs:
             git push "${remote_repo}" HEAD:gh-pages
     - name: Request GitHub Pages Build
       env:
-            GITHUB_TOKEN: ${{ secrets.DOCS_SITE_TOKEN }}
-            GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
-            GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
             # As documented here, the GH-Pages behavior changed, and the API must be 'Triggered'
             # https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/m-p/43192/highlight/true#M5281

--- a/build/release/bin/10_build/3_build.sh
+++ b/build/release/bin/10_build/3_build.sh
@@ -14,12 +14,14 @@ set -eu -o pipefail
 export BUILD_PROFILES=" $(jq -r '.build[] | select(.type == "fhir-tools").profiles | map(.) | join(",")' build/release/config/release.json)"
 mvn install source:jar source:test-jar javadoc:jar -f fhir-tools \
         -DadditionalJOption=-Xdoclint:none \
+        -Dsurefire.failIfNoSpecifiedTests=false \
         -f fhir-tools -P "${BUILD_PROFILES}" -DskipTests
 
 # fhir-examples
 export BUILD_PROFILES=" $(jq -r '.build[] | select(.type == "fhir-examples").profiles | map(.) | join(",")' build/release/config/release.json)"
 mvn install source:jar source:test-jar javadoc:jar -f fhir-examples \
         -DadditionalJOption=-Xdoclint:none \
+        -Dsurefire.failIfNoSpecifiedTests=false \
         -f fhir-examples -P "${BUILD_PROFILES}" -DskipTests
 
 # fhir-parent
@@ -27,6 +29,7 @@ export BUILD_PROFILES=" $(jq -r '.build[] | select(.type == "fhir-parent").profi
 mvn install -f fhir-parent -DskipTests
 mvn install source:jar source:test-jar javadoc:jar -f fhir-parent \
         -DadditionalJOption=-Xdoclint:none \
+        -Dsurefire.failIfNoSpecifiedTests=false \
         -f fhir-parent -P "${BUILD_PROFILES}" -DskipTests
 
 # EOF


### PR DESCRIPTION
I also added `-Dsurefire.failIfNoSpecifiedTests=false` to the release script to avoid an issue I saw where the lack of tests in one module caused the entire release process to fail.

Signed-off-by: Lee Surprenant <lmsurpre@merative.com>