### PR TITLE
set failIfNoSpecifiedTests in the right spot

### DIFF
--- a/build/release/bin/10_build/3_build.sh
+++ b/build/release/bin/10_build/3_build.sh
@@ -14,22 +14,19 @@ set -eu -o pipefail
 export BUILD_PROFILES=" $(jq -r '.build[] | select(.type == "fhir-tools").profiles | map(.) | join(",")' build/release/config/release.json)"
 mvn install source:jar source:test-jar javadoc:jar -f fhir-tools \
         -DadditionalJOption=-Xdoclint:none \
-        -Dsurefire.failIfNoSpecifiedTests=false \
-        -f fhir-tools -P "${BUILD_PROFILES}" -DskipTests
+        -P "${BUILD_PROFILES}" -DskipTests
 
 # fhir-examples
 export BUILD_PROFILES=" $(jq -r '.build[] | select(.type == "fhir-examples").profiles | map(.) | join(",")' build/release/config/release.json)"
 mvn install source:jar source:test-jar javadoc:jar -f fhir-examples \
         -DadditionalJOption=-Xdoclint:none \
-        -Dsurefire.failIfNoSpecifiedTests=false \
-        -f fhir-examples -P "${BUILD_PROFILES}" -DskipTests
+        -P "${BUILD_PROFILES}" -DskipTests
 
 # fhir-parent
 export BUILD_PROFILES=" $(jq -r '.build[] | select(.type == "fhir-parent").profiles | map(.) | join(",")' build/release/config/release.json)"
 mvn install -f fhir-parent -DskipTests
 mvn install source:jar source:test-jar javadoc:jar -f fhir-parent \
         -DadditionalJOption=-Xdoclint:none \
-        -Dsurefire.failIfNoSpecifiedTests=false \
-        -f fhir-parent -P "${BUILD_PROFILES}" -DskipTests
+        -P "${BUILD_PROFILES}" -DskipTests
 
 # EOF

--- a/build/release/bin/20_test/1_code_coverage.sh
+++ b/build/release/bin/20_test/1_code_coverage.sh
@@ -36,6 +36,7 @@ mvn -T2C test org.jacoco:jacoco-maven-plugin:0.8.7:report-aggregate -f fhir-exam
 
 # fhir-parent
 export BUILD_PROFILES=" $(jq -r '.build[] | select(.type == "fhir-parent").profiles | map(.) | join(",")' build/release/config/release.json)"
-mvn -T2C test org.jacoco:jacoco-maven-plugin:0.8.7:report-aggregate -f fhir-parent -P "${BUILD_PROFILES}" -DfailIfNoTests=false -Dtest=$(tests)
+mvn -T2C test org.jacoco:jacoco-maven-plugin:0.8.7:report-aggregate -f fhir-parent \
+        -P "${BUILD_PROFILES}" -Dsurefire.failIfNoSpecifiedTests=false -Dtest=$(tests)
 
 # EOF


### PR DESCRIPTION
I tried tagging 5.0.0-RC1, but the "build and release" workflow failed with the following errors:
```
2022-08-18T02:23:27.9937870Z [ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M7:test (default-test) on project fhir-openapi: No tests matching pattern "'!org.linuxforhealth.fhir.ig.us.spl.ExamplesValidationTest'" were executed! (Set -Dsurefire.failIfNoSpecifiedTests=false to ignore this error.) -> [Help 1]
2022-08-18T02:23:27.9939554Z [ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M7:test (default-test) on project fhir-core: No tests matching pattern "'!org.linuxforhealth.fhir.ig.us.spl.ExamplesValidationTest'" were executed! (Set -Dsurefire.failIfNoSpecifiedTests=false to ignore this error.) -> [Help 1]
2022-08-18T02:23:27.9949339Z [ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M7:test (default-test) on project fhir-database-utils: No tests matching pattern "'!org.linuxforhealth.fhir.ig.us.spl.ExamplesValidationTest'" were executed! (Set -Dsurefire.failIfNoSpecifiedTests=false to ignore this error.) -> [Help 1]
```

I tried addressing that by adding the suggested property but I accidentally added it to the wrong place.  This commit should fix that.

Signed-off-by: Lee Surprenant <lmsurpre@merative.com>