### PR TITLE
dependency version bumps

### DIFF
--- a/fhir-examples/pom.xml
+++ b/fhir-examples/pom.xml
@@ -112,32 +112,32 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>2.11.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.8.2</version>
+                    <version>3.12.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>2.9</version>
+                    <version>3.4.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.8</version>
+                    <version>1.6.13</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
-                    <version>1.6</version>
+                    <version>3.0.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -320,12 +320,6 @@
                 <version>3.23.0</version>
             </dependency>
             <dependency>
-                <!-- used by fhir-provider and commons-text -->
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>3.12.0</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
                 <version>3.2.0</version>
@@ -374,6 +368,34 @@
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
                 <version>1.15</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.11.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-collections4</artifactId>
+                <version>4.4</version>
+            </dependency>
+            <dependency>
+                <!-- used by org.janusgraph:janusgraph-core -->
+                <!-- [CVE-2022-33980] CWE-74: Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection'); patched in 2.8.0 -->
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <version>2.8.0</version>
+            </dependency>
+            <dependency>
+                <!-- used by fhir-provider and commons-text -->
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.12.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>1.9</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.parsson</groupId>
@@ -512,16 +534,6 @@
                 <version>7.1.17</version>
             </dependency>
             <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>2.11.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-text</artifactId>
-                <version>1.9</version>
-            </dependency>
-            <dependency>
                 <groupId>org.janusgraph</groupId>
                 <artifactId>janusgraph-core</artifactId>
                 <version>0.6.2</version>
@@ -625,6 +637,13 @@
                 <version>4.1.79.Final</version>
             </dependency>
             <dependency>
+                <!-- Used in com.datastax.oss:java-driver-core -->
+                <!-- [CVE-2022-24823] CWE-378: Creation of Temporary File With Insecure Permissions; patched in 4.1.77.Final -->
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>4.1.79.Final</version>
+            </dependency>
+            <dependency>
                 <!--  [CVE-2020-8908] A temp directory creation vulnerability exists in all versions of Guava, addressed in latest versions -->
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
@@ -657,11 +676,6 @@
                         <artifactId>javaparser</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-collections4</artifactId>
-                <version>4.4</version>
             </dependency>
             <dependency>
                 <groupId>com.github.tomakehurst</groupId>
@@ -704,6 +718,13 @@
                 <groupId>org.jgrapht</groupId>
                 <artifactId>jgrapht-core</artifactId>
                 <version>1.5.1</version>
+            </dependency>
+            <dependency>
+                <!-- used by org.apache.tinkerpop:gremlin-driver -->
+                <!-- [CVE-2018-18928] CWE-190: Integer Overflow or Wraparound; unclear whether it affects icu4j at all, but 63.2 is the patched version of ICU -->
+                <groupId>com.ibm.icu</groupId>
+                <artifactId>icu4j</artifactId>
+                <version>71.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -820,7 +841,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -1383,6 +1404,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.13</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>


### PR DESCRIPTION
1. lock in to specific versions for a few transitive dependencies that were flagged by sonatype
   * manage commons-configuration2 to 2.8.0
   * manage netty-handler to 4.1.79.Final (we already managed other netty modules but com.datastax.oss:java-driver-core specifically depends on the handler)
   * manage icu4j to 71.1

2. group the apache commons dependencies together in fhir-parent

3. add a version for the nexus-staging-maven-plugin plugin

4. update the fhir-examples plugin versions to match the plugin versions from fhir-parent

Signed-off-by: Lee Surprenant <lmsurpre@merative.com>