### PR TITLE
add ghcr.io prefix to build scripts for the other container images

### DIFF
--- a/fhir-install/src/main/docker/fhir-bucket-tool/build.sh
+++ b/fhir-install/src/main/docker/fhir-bucket-tool/build.sh
@@ -27,13 +27,13 @@ mkdir -p target/
 cp ${WORKSPACE}/fhir-bucket/target/fhir-bucket-*cli.jar target/
 cp ${WORKSPACE}/LICENSE target/
 
-docker build --build-arg FHIR_VERSION=${BUILD_ID} -t fhir-bucket-tool:latest .
-DOCKER_IMAGE=$(docker images --filter=reference='fhir-bucket-tool:latest' --format "{{.ID}}")
+docker build --build-arg FHIR_VERSION=${BUILD_ID} -t linuxforhealth/fhir-bucket-tool:latest .
+DOCKER_IMAGE=$(docker images --filter=reference='linuxforhealth/fhir-bucket-tool:latest' --format "{{.ID}}")
 echo "Docker Image is:  ${DOCKER_IMAGE}"
 
-docker tag ${DOCKER_IMAGE} linuxforhealth/fhir-bucket-tool:${BUILD_ID}
-docker tag ${DOCKER_IMAGE} linuxforhealth/fhir-bucket-tool:latest
-docker push linuxforhealth/fhir-bucket-tool:${BUILD_ID}
-docker push linuxforhealth/fhir-bucket-tool:latest
+docker tag ${DOCKER_IMAGE} ghcr.io/linuxforhealth/fhir-bucket-tool:${BUILD_ID}
+docker tag ${DOCKER_IMAGE} ghcr.io/linuxforhealth/fhir-bucket-tool:latest
+docker push ghcr.io/linuxforhealth/fhir-bucket-tool:${BUILD_ID}
+docker push ghcr.io/linuxforhealth/fhir-bucket-tool:latest
 
 popd > /dev/null

--- a/fhir-install/src/main/docker/fhir-schematool/build.sh
+++ b/fhir-install/src/main/docker/fhir-schematool/build.sh
@@ -31,14 +31,14 @@ mkdir -p target/
 cp ${WORKSPACE}/fhir-persistence-schema/target/fhir-persistence-schema-*cli.jar target/
 cp ${WORKSPACE}/LICENSE target/
 
-docker build --build-arg FHIR_VERSION=${BUILD_ID} -t fhir-schematool:latest .
-DOCKER_IMAGE=$(docker images --filter=reference='fhir-schematool:latest' --format "{{.ID}}")
+docker build --build-arg FHIR_VERSION=${BUILD_ID} -t linuxforhealth/fhir-schematool:latest .
+DOCKER_IMAGE=$(docker images --filter=reference='linuxforhealth/fhir-schematool:latest' --format "{{.ID}}")
 echo "Docker Image is:  ${DOCKER_IMAGE}"
 
-docker tag ${DOCKER_IMAGE} linuxforhealth/fhir-schematool:${BUILD_ID}
-docker tag ${DOCKER_IMAGE} linuxforhealth/fhir-schematool:latest
-docker push linuxforhealth/fhir-schematool:${BUILD_ID}
-docker push linuxforhealth/fhir-schematool:latest
+docker tag ${DOCKER_IMAGE} ghcr.io/linuxforhealth/fhir-schematool:${BUILD_ID}
+docker tag ${DOCKER_IMAGE} ghcr.io/linuxforhealth/fhir-schematool:latest
+docker push ghcr.io/linuxforhealth/fhir-schematool:${BUILD_ID}
+docker push ghcr.io/linuxforhealth/fhir-schematool:latest
 
 popd > /dev/null
 

--- a/fhir-install/src/main/docker/fhir-term-graph-loader/build.sh
+++ b/fhir-install/src/main/docker/fhir-term-graph-loader/build.sh
@@ -35,10 +35,10 @@ docker build --build-arg FHIR_VERSION=${BUILD_ID} -t linuxforhealth/fhir-term-lo
 DOCKER_IMAGE=$(docker images --filter=reference='linuxforhealth/fhir-term-loader:latest' --format "{{.ID}}")
 echo "Docker Image is:  ${DOCKER_IMAGE}"
 
-docker tag ${DOCKER_IMAGE} linuxforhealth/fhir-term-loader:${BUILD_ID}
-docker tag ${DOCKER_IMAGE} linuxforhealth/fhir-term-loader:latest
-docker push linuxforhealth/fhir-term-loader:${BUILD_ID}
-docker push linuxforhealth/fhir-term-loader:latest
+docker tag ${DOCKER_IMAGE} ghcr.io/linuxforhealth/fhir-term-loader:${BUILD_ID}
+docker tag ${DOCKER_IMAGE} ghcr.io/linuxforhealth/fhir-term-loader:latest
+docker push ghcr.io/linuxforhealth/fhir-term-loader:${BUILD_ID}
+docker push ghcr.io/linuxforhealth/fhir-term-loader:latest
 
 popd > /dev/null
 


### PR DESCRIPTION
In 5.0.0-RC1, only the linuxforhealth/fhir-server image was successfully pushed to
the GitHub container registry. I'm hoping that, with these changes, when we tag
RC2 it will push all of the desired images to the registry.

Signed-off-by: Lee Surprenant <lmsurpre@merative.com>