### PR TITLE
issue #3854 - patch ClinicalUseDefinition search params

### DIFF
--- a/conformance/fhir-core-r4b/src/main/resources/hl7/fhir/core/430/package/SearchParameter-ClinicalUseDefinition-contraindication-reference.json
+++ b/conformance/fhir-core-r4b/src/main/resources/hl7/fhir/core/430/package/SearchParameter-ClinicalUseDefinition-contraindication-reference.json
@@ -38,7 +38,7 @@
         "ClinicalUseDefinition"
     ],
     "type": "reference",
-    "expression": "ClinicalUseDefinition.contraindication.diseaseSymptomProcedure",
+    "expression": "ClinicalUseDefinition.contraindication.diseaseSymptomProcedure.reference",
     "xpath": "f:ClinicalUseDefinition/f:contraindication/f:diseaseSymptomProcedure",
     "xpathUsage": "normal"
 }

--- a/conformance/fhir-core-r4b/src/main/resources/hl7/fhir/core/430/package/SearchParameter-ClinicalUseDefinition-contraindication.json
+++ b/conformance/fhir-core-r4b/src/main/resources/hl7/fhir/core/430/package/SearchParameter-ClinicalUseDefinition-contraindication.json
@@ -38,7 +38,7 @@
         "ClinicalUseDefinition"
     ],
     "type": "token",
-    "expression": "ClinicalUseDefinition.contraindication.diseaseSymptomProcedure",
+    "expression": "ClinicalUseDefinition.contraindication.diseaseSymptomProcedure.concept",
     "xpath": "f:ClinicalUseDefinition/f:contraindication/f:diseaseSymptomProcedure",
     "xpathUsage": "normal"
 }

--- a/conformance/fhir-core-r4b/src/main/resources/hl7/fhir/core/430/package/SearchParameter-ClinicalUseDefinition-effect-reference.json
+++ b/conformance/fhir-core-r4b/src/main/resources/hl7/fhir/core/430/package/SearchParameter-ClinicalUseDefinition-effect-reference.json
@@ -38,7 +38,7 @@
         "ClinicalUseDefinition"
     ],
     "type": "reference",
-    "expression": "ClinicalUseDefinition.undesirableEffect.symptomConditionEffect",
+    "expression": "ClinicalUseDefinition.undesirableEffect.symptomConditionEffect.reference",
     "xpath": "f:ClinicalUseDefinition/f:undesirableEffect/f:symptomConditionEffect",
     "xpathUsage": "normal"
 }

--- a/conformance/fhir-core-r4b/src/main/resources/hl7/fhir/core/430/package/SearchParameter-ClinicalUseDefinition-effect.json
+++ b/conformance/fhir-core-r4b/src/main/resources/hl7/fhir/core/430/package/SearchParameter-ClinicalUseDefinition-effect.json
@@ -38,7 +38,7 @@
         "ClinicalUseDefinition"
     ],
     "type": "token",
-    "expression": "ClinicalUseDefinition.undesirableEffect.symptomConditionEffect",
+    "expression": "ClinicalUseDefinition.undesirableEffect.symptomConditionEffect.concept",
     "xpath": "f:ClinicalUseDefinition/f:undesirableEffect/f:symptomConditionEffect",
     "xpathUsage": "normal"
 }

--- a/conformance/fhir-core-r4b/src/main/resources/hl7/fhir/core/430/package/SearchParameter-ClinicalUseDefinition-indication-reference.json
+++ b/conformance/fhir-core-r4b/src/main/resources/hl7/fhir/core/430/package/SearchParameter-ClinicalUseDefinition-indication-reference.json
@@ -38,7 +38,7 @@
         "ClinicalUseDefinition"
     ],
     "type": "reference",
-    "expression": "ClinicalUseDefinition.indication.diseaseSymptomProcedure",
+    "expression": "ClinicalUseDefinition.indication.diseaseSymptomProcedure.reference",
     "xpath": "f:ClinicalUseDefinition/f:indication/f:diseaseSymptomProcedure",
     "xpathUsage": "normal"
 }

--- a/conformance/fhir-core-r4b/src/main/resources/hl7/fhir/core/430/package/SearchParameter-ClinicalUseDefinition-indication.json
+++ b/conformance/fhir-core-r4b/src/main/resources/hl7/fhir/core/430/package/SearchParameter-ClinicalUseDefinition-indication.json
@@ -38,7 +38,7 @@
         "ClinicalUseDefinition"
     ],
     "type": "token",
-    "expression": "ClinicalUseDefinition.indication.diseaseSymptomProcedure",
+    "expression": "ClinicalUseDefinition.indication.diseaseSymptomProcedure.concept",
     "xpath": "f:ClinicalUseDefinition/f:indication/f:diseaseSymptomProcedure",
     "xpathUsage": "normal"
 }

--- a/fhir-search/src/test/java/org/linuxforhealth/fhir/search/tool/SearchParameterAugmenter.java
+++ b/fhir-search/src/test/java/org/linuxforhealth/fhir/search/tool/SearchParameterAugmenter.java
@@ -6,12 +6,15 @@
 package org.linuxforhealth.fhir.search.tool;
 
 import java.io.BufferedWriter;
+import java.io.FileNotFoundException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.linuxforhealth.fhir.core.ResourceType;
 import org.linuxforhealth.fhir.model.format.Format;
@@ -20,13 +23,16 @@ import org.linuxforhealth.fhir.model.resource.Resource;
 import org.linuxforhealth.fhir.model.resource.SearchParameter;
 import org.linuxforhealth.fhir.model.test.TestUtil;
 import org.linuxforhealth.fhir.model.type.Code;
+import org.linuxforhealth.fhir.model.type.CodeableReference;
 import org.linuxforhealth.fhir.model.type.Element;
 import org.linuxforhealth.fhir.model.type.Extension;
 import org.linuxforhealth.fhir.model.type.Uri;
 import org.linuxforhealth.fhir.model.type.code.ResourceTypeCode;
+import org.linuxforhealth.fhir.model.type.code.SearchParamType;
 import org.linuxforhealth.fhir.model.util.ModelSupport;
 import org.linuxforhealth.fhir.path.FHIRPathNode;
 import org.linuxforhealth.fhir.path.evaluator.FHIRPathEvaluator;
+import org.linuxforhealth.fhir.path.exception.FHIRPathException;
 import org.linuxforhealth.fhir.registry.FHIRRegistry;
 import org.linuxforhealth.fhir.search.SearchConstants;
 
@@ -38,30 +44,29 @@ public class SearchParameterAugmenter {
     private static final FHIRGenerator generator = FHIRGenerator.generator(Format.JSON, true);
 
     public static void main(String[] args) throws Exception {
-        Collection<SearchParameter> tokenParams = FHIRRegistry.getInstance().getSearchParameters("token");
+        Set<SearchParameter> params = new HashSet<>();
+        params.addAll(FHIRRegistry.getInstance().getSearchParameters("token"));
+        params.addAll(FHIRRegistry.getInstance().getSearchParameters("reference"));
 
-        for (SearchParameter searchParameter : tokenParams) {
+        for (SearchParameter searchParameter : params) {
             List<ResourceTypeCode> base = searchParameter.getBase();
             if (base.size() != 1 || base.get(0).getValueAsEnum() == ResourceType.RESOURCE) {
                 continue; // too complicated to handle this case right now
             }
 
-            Resource sampleResource = TestUtil.readExampleResource("json/complete-mock/" + base.get(0).getValue() + "-1.json");
+            String expression = searchParameter.getExpression().getValue();
 
-            Collection<FHIRPathNode> nodes = FHIRPathEvaluator.evaluator().evaluate(sampleResource, searchParameter.getExpression().getValue());
-
-            if (nodes.size() != 1) {
-                continue; // too complicated to handle this case right now
+            FHIRPathNode node = getExampleNodeIfPossible(searchParameter, base);
+            if (node == null) {
+                System.err.println("Skipping " + searchParameter.getId() + " because we couldn't infer the element type from "
+                        + "'" + searchParameter.getExpression().getValue() + "'");
+                continue;
             }
-
-            FHIRPathNode node = nodes.iterator().next();
-
-            if (!node.isElementNode()) {
-                continue; // too complicated to handle this case right now
-            }
-
             Element element = node.asElementNode().element();
-            if (element instanceof Code) {
+
+            Path pathToSPDef = Paths.get("../conformance/fhir-core-r4b/src/main/resources/hl7/fhir/core/430/package/SearchParameter-"
+                    + searchParameter.getId() + ".json");
+            if (element instanceof Code && SearchParamType.Value.TOKEN == searchParameter.getType().getValueAsEnum()) {
                 String system = ModelSupport.getSystem(element.as(Code.class));
 
                 if (system != null) {
@@ -86,13 +91,63 @@ public class SearchParameterAugmenter {
                                 "' already has an implicity system extension and it doesn't match '" + system + "'");
                     }
 
-                    Path path = Paths.get("../conformance/fhir-core-r4b/src/main/resources/hl7/fhir/core/430/package/SearchParameter-"
-                            + searchParameter.getId() + ".json");
-                    BufferedWriter writer = Files.newBufferedWriter(path, Charset.forName("UTF-8"));
+                    try (BufferedWriter writer = Files.newBufferedWriter(pathToSPDef, Charset.forName("UTF-8"))) {
+                        generator.generate(searchParameter, writer);
+                    }
+                }
+            } else if (element instanceof CodeableReference) {
+                // https://jira.hl7.org/browse/FHIR-37867
+                if (SearchParamType.Value.REFERENCE == searchParameter.getType().getValueAsEnum()) {
+                    System.out.println("patching CodeableReference search parameter expression to select the reference");
+                    searchParameter = searchParameter.toBuilder()
+                            .expression(expression + ".reference")
+                            .build();
+                } else if (SearchParamType.Value.TOKEN == searchParameter.getType().getValueAsEnum()) {
+                    System.out.println("patching CodeableReference search parameter expression to select the concept");
+                    searchParameter = searchParameter.toBuilder()
+                            .expression(expression + ".concept")
+                            .build();
+                }
+
+                try (BufferedWriter writer = Files.newBufferedWriter(pathToSPDef, Charset.forName("UTF-8"))) {
                     generator.generate(searchParameter, writer);
                 }
             }
         }
+    }
+
+    private static FHIRPathNode getExampleNodeIfPossible(SearchParameter searchParameter, List<ResourceTypeCode> base)
+            throws Exception, FHIRPathException {
+        FHIRPathNode node = null;
+        // try up to five examples to find the node
+        try {
+            for (int i = 1; i <= 5; i++) {
+                Resource sampleResource = TestUtil.readExampleResource("json/complete-mock/" + base.get(0).getValue() + "-" + i + ".json");
+
+                Collection<FHIRPathNode> nodes = FHIRPathEvaluator.evaluator().evaluate(sampleResource, searchParameter.getExpression().getValue());
+
+                if (nodes.size() == 0) {
+                    // keep looking in other examples for this element
+                    continue;
+                } else if (nodes.size() > 1) {
+                    System.out.println("Skipping " + searchParameter.getId() + " because the complete-mock example has multiple elements for "
+                            + "'" + searchParameter.getExpression().getValue() + "'");
+                    continue;
+                }
+
+                FHIRPathNode selectedNode = nodes.iterator().next();
+
+                if (selectedNode.isElementNode()) {
+                    node = selectedNode;
+                } else {
+                    System.out.println("Skipping " + searchParameter.getId() + " because the complete-mock example has a non-element node for "
+                            + "'" + searchParameter.getExpression().getValue() + "'");
+                }
+            }
+        } catch (FileNotFoundException e) {
+            // we didn't find the node before running out of examples
+        }
+        return node;
     }
 
     public static Extension buildImplicitSystemExtension(String implicitSystemValue) {


### PR DESCRIPTION
Initially I had planned to add support in JDBCParameterBuildingVisitor
for visiting CodeableReference elements. However, because the FHIR
community decided that expressions should *not* target CodeableReference
elements, I decided to patch the offending R4B SearchParameter
definitions instead.

Signed-off-by: Lee Surprenant <lmsurpre@merative.com>