### PR TITLE
issue #3859 - track retired tables (and views) in the model so we can drop them

### DIFF
--- a/build/migration/postgres/8_teardown.sh
+++ b/build/migration/postgres/8_teardown.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+###############################################################################
+# (C) Copyright IBM Corp. 2021, 2022
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################################
+
+set -ex
+
+echo "- Dropping Schema"
+java -jar ${WORKSPACE}/fhir/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
+    --db-type postgresql --prop db.host=localhost --prop db.port=5432 --prop db.database=fhirdb \
+    --prop user=fhiradmin --prop password=change-password \
+    --schema-name FHIRDATA --drop-schema-fhir --confirm-drop --pool-size 1

--- a/build/post-integration-test-docker.sh
+++ b/build/post-integration-test-docker.sh
@@ -45,7 +45,7 @@ else
     # Grab the container's console log
     docker logs $containerId  >& ${it_results}/docker-console.txt
 
-    echo "Gathering pre-test server logs from docker container: $containerId"
+    echo "Gathering post-test server logs from docker container: $containerId"
     docker cp -L $containerId:/logs ${it_results}/server-logs
 fi
 

--- a/fhir-database-utils/src/main/java/org/linuxforhealth/fhir/database/utils/model/Table.java
+++ b/fhir-database-utils/src/main/java/org/linuxforhealth/fhir/database/utils/model/Table.java
@@ -51,7 +51,7 @@ public class Table extends BaseObject {
 
     // The With parameters on the table
     private final List<With> withs;
-    
+
     private final List<CheckConstraint> checkConstraints = new ArrayList<>();
 
     // Do we still want to create this table?
@@ -80,7 +80,7 @@ public class Table extends BaseObject {
      * @param distributionColumnName
      * @param create
      */
-    public Table(String schemaName, String name, int version, 
+    public Table(String schemaName, String name, int version,
             Collection<ColumnBase> columns, PrimaryKeyDef pk,
             IdentityDef identity, Collection<IndexDef> indexes, Collection<ForeignKeyConstraint> fkConstraints,
             Tablespace tablespace, List<IDatabaseObject> dependencies, Map<String,String> tags,
@@ -125,7 +125,7 @@ public class Table extends BaseObject {
 
     /**
      * Getter for the create flag
-     * @return
+     * @return whether the table should be created or not
      */
     public boolean isCreate() {
         return this.create;
@@ -147,7 +147,7 @@ public class Table extends BaseObject {
         }
 
         final String tsName = this.tablespace == null ? null : this.tablespace.getName();
-        target.createTable(getSchemaName(), getObjectName(), this.columns, 
+        target.createTable(getSchemaName(), getObjectName(), this.columns,
             this.primaryKey, this.identity, tsName, this.withs, this.checkConstraints,
             this.distributionType, this.distributionColumnName);
 
@@ -225,9 +225,6 @@ public class Table extends BaseObject {
         // other dependencies of this table
         private Set<IDatabaseObject> dependencies = new HashSet<>();
 
-        // Is this table multi-tenant when supported?
-        private String tenantColumnName;
-
         // A map of tags
         private Map<String,String> tags = new HashMap<>();
 
@@ -239,7 +236,7 @@ public class Table extends BaseObject {
 
         // With metadata on the Table
         private List<With> withs = new ArrayList<>();
-        
+
         // Check constraints added to the table
         private List<CheckConstraint> checkConstraints = new ArrayList<>();
 
@@ -283,7 +280,7 @@ public class Table extends BaseObject {
 
         /**
          * Setter for the create flag
-         * @param ts
+         * @param flag true is the default for new tables; set to false to avoid creating this table
          * @return
          */
         public Builder setCreate(boolean flag) {
@@ -658,7 +655,7 @@ public class Table extends BaseObject {
             this.uniqueConstraints.put(constraintName, new UniqueConstraint(constraintName, columnName));
             return this;
         }
-        
+
         public Builder addCheckConstraint(String constraintName, String constraintExpression) {
             this.checkConstraints.add(new CheckConstraint(constraintName, constraintExpression));
             return this;
@@ -790,7 +787,7 @@ public class Table extends BaseObject {
                         // as the target isn't sharded (replicated is OK)
                         if (targetDistributionType == DistributionType.REFERENCE) {
                             allDependencies.add(target);
-                            enabledFKConstraints.add(c);                        
+                            enabledFKConstraints.add(c);
                         }
                     } else if (distributionType == DistributionType.REFERENCE) {
                         // This table is a reference (replicated) table. We can create FK relationships

--- a/fhir-persistence-schema/src/main/java/org/linuxforhealth/fhir/schema/control/FhirSchemaGenerator.java
+++ b/fhir-persistence-schema/src/main/java/org/linuxforhealth/fhir/schema/control/FhirSchemaGenerator.java
@@ -219,10 +219,12 @@ public class FhirSchemaGenerator {
     }
 
     /**
-     * Generate the IBM FHIR Server Schema with just the given resourceTypes
+     * Generate the LinuxForHealth FHIR Server Schema with just the given resourceTypes
      *
      * @param adminSchemaName
      * @param schemaName
+     * @param resourceTypes
+     * @throws IllegalArgumentException if one or more of the resource types are not valid FHIR resource types
      */
     public FhirSchemaGenerator(String adminSchemaName, String schemaName, SchemaType schemaType, Set<String> resourceTypes) {
         this.adminSchemaName = adminSchemaName;
@@ -250,6 +252,11 @@ public class FhirSchemaGenerator {
         // FHIRSERVER gets to use the FHIR sequence
         sequencePrivileges.add(new GroupPrivilege(FhirSchemaConstants.FHIR_USER_GRANT_GROUP, Privilege.USAGE));
 
+        for (String resourceType : resourceTypes) {
+            if (!ALL_RESOURCE_TYPES.contains(resourceType.toUpperCase())) {
+                throw new IllegalArgumentException("Passed resource type '" + resourceType + "' is not a valid resource type");
+            }
+        }
         this.resourceTypes = resourceTypes;
     }
 
@@ -1136,8 +1143,6 @@ public class FhirSchemaGenerator {
             if (RETIRED_TYPES.contains(resourceType)) {
                 logger.warning("Passed resource type '" + resourceType + "' has been retired in FHIR 4.3; corresponding tables will not be created");
                 isRetired = true;
-            } else if (!ALL_RESOURCE_TYPES.contains(resourceType)) {
-                logger.warning("Passed resource type '" + resourceType + "' is not a valid resource type; proceeding anyway");
             }
 
             ObjectGroup group = frg.addResourceType(resourceType, isRetired);


### PR DESCRIPTION
After the previous changes, dropping a schema that was created with a
4.x version of fhir-persistence-schema was failing because we never
dropped the tables that have been removed from the model.
With these changes, we flag the removed resource types as "retired" and
avoid their creation in new schemas that way (vs. leaving them out of
the model entirely).

We could potentially remove this logic if we ever get to
https://github.com/LinuxForHealth/FHIR/issues/3263

I also added `@Deprecated` annotations for old migration steps in our fhir-persistence-schema
Main which I'm thinking we can remove whenever we bump to 6.0 (so we'll continue to support 
any 4.x to 5.x migration, but not 4.x to 6.x).

Signed-off-by: Lee Surprenant <lmsurpre@merative.com>