### PR TITLE
issue #3919 - validate Resource.id when invoked at instance level

### DIFF
--- a/operation/fhir-operation-validate/src/main/java/org/linuxforhealth/fhir/operation/validate/ValidateOperation.java
+++ b/operation/fhir-operation-validate/src/main/java/org/linuxforhealth/fhir/operation/validate/ValidateOperation.java
@@ -12,6 +12,7 @@ import static org.linuxforhealth.fhir.model.type.Xhtml.xhtml;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.linuxforhealth.fhir.exception.FHIROperationException;
 import org.linuxforhealth.fhir.model.resource.OperationDefinition;
@@ -47,38 +48,51 @@ public class ValidateOperation extends AbstractOperation {
 
     @Override
     protected Parameters doInvoke(FHIROperationContext operationContext, Class<? extends Resource> resourceType, String logicalId,
-            String versionId, Parameters parameters, FHIRResourceHelpers resourceHelper, SearchHelper searchHelper) throws FHIROperationException {
+            String versionId, Parameters parameters, FHIRResourceHelpers resourceHelper, SearchHelper searchHelper)
+            throws FHIROperationException {
+        Objects.requireNonNull(operationContext, "operations framework prevents operationContext from being null");
+        Objects.requireNonNull(resourceType, "operations framework should prevent resourceType from being null "
+                + "because $validate must be invoked at the resource type or instance level");
+
         try {
+            List<OperationOutcome.Issue> issues = new ArrayList<>();
+
             Parameter resourceParameter = getParameter(parameters, "resource");
-            String resourceTypeName = resourceType != null ? resourceType.getSimpleName() : null;
             Parameter modeParameter = getParameter(parameters, "mode");
-            ModeType modeType = getModeType(modeParameter);
-            // Validate the resource parameter
-            Resource resource = validateResource(operationContext, logicalId, resourceHelper, resourceParameter, resourceTypeName, modeType);
-            
-            List<OperationOutcome.Issue> issues;
             Parameter profileParameter = getParameter(parameters, "profile");
-            
-            // Validate mode parameter.
-            validateModeParameter(modeType, resourceHelper, resourceTypeName, operationContext, logicalId);
+
+            String resourceTypeName = resourceType.getSimpleName();
+            ModeType modeType = getModeType(modeParameter);
+
+            // Validate the resource parameter
+            Resource resource = getResource(operationContext, logicalId, resourceHelper, resourceParameter, resourceTypeName, modeType);
+
+            // Validate the mode parameter
+            issues.addAll(validateModeAndInteraction(modeType, resourceHelper, resourceTypeName, operationContext, logicalId));
+
+            // Additional checks when invoked at the instance level
+            if (operationContext.getType() == FHIROperationContext.Type.INSTANCE) {
+                issues.addAll(validateInstanceLevelInvoke(operationContext, logicalId, resourceHelper, resource, resourceTypeName, modeType));
+            }
 
             if (profileParameter != null && profileParameter.getValue() != null) {
                 // If the 'profile' parameter is specified, always validate the resource against that profile.
                 Uri profileUri = profileParameter.getValue().as(Uri.class);
                 String profile = profileUri == null ? null : profileUri.getValue();
-                issues = FHIRValidator.validator().validate(resource, profile);
+                issues.addAll(FHIRValidator.validator().validate(resource, profile));
             } else if (modeType == ModeType.CREATE || modeType == ModeType.UPDATE) {
                 // If the 'mode' parameter is specified and its value is 'create' or 'update', validate the resource
                 // against the FHIR server config's profile properties and the resource's asserted profiles.
-                issues = resourceHelper.validateResource(resource);
+                issues.addAll(resourceHelper.validateResource(resource));
             } else if (modeType == ModeType.DELETE && operationContext.getType() == FHIROperationContext.Type.INSTANCE) {
                 // If the 'mode' parameter is specified and its value is 'delete' and delete is invoked at the resource-instance level,
                 // validate if the persistence layer implementation supports the "delete" operation
-                issues = validateDeleteResource(resourceTypeName, logicalId, operationContext);
+                issues.addAll(validateDeleteResource(resourceTypeName, logicalId, operationContext));
             } else {
                 // Standard validation against the resource's asserted profiles.
-                issues = FHIRValidator.validator().validate(resource);
-            } 
+                issues.addAll(FHIRValidator.validator().validate(resource));
+            }
+
             return FHIROperationUtil.getOutputParameters(buildResourceValidOperationOutcome(issues));
         } catch (FHIROperationException e) {
             throw e;
@@ -113,100 +127,94 @@ public class ValidateOperation extends AbstractOperation {
 
         return operationOutcome;
     }
-    
-    
+
+
     /**
-     * This method does the following validations if modeType(mode parameter) is not null. If the mode parameter is null then the below validations are skipped.
-     * 1. Validate an interaction for a specified resource type.
-     * 2. Validate if persistence layer implementation supports update/create mode if mode = create.
-     * 3. Validate if persistence layer implementation supports update/create mode if mode = update but the resource doesnot exist yet in the DB.
-     * 4. Validate if modes update and delete are only be used when the operation is invoked at the resource instance level
-     *
-     * @param modeParameter resource validation mode code to be validated
+     * Validate that the mode is supported for this invocation (update and delete are only supported at the instance level)
+     * and that the corresponding interaction is enabled for the passed resource type.
+     * @param modeType resource validation mode code to be validated
      * @param resourceHelper Resource operation provider for loading related Library resources
      * @param resourceType a valid resource type string
-     * @param operationContext the FHIROperationContext associated with the request
-     * @throws Exception 
+     * @param operationContext the FHIROperationContext associated with the request; never null
+     * @param logicalId the resource id included in the invocation request (if invoked at the instance level)
+     * @return List<Issue> - a non-null, possibly-empty list of issues that indicate why the resource is not valid for the passed modeType
+     * @throws FHIROperationException if the operation was invoked at the resource type level with mode = update or delete
      */
-    private void validateModeParameter(ModeType modetype, FHIRResourceHelpers resourceHelper, String resourceType, FHIROperationContext operationContext, String logicalId) throws Exception {
-        if (modetype == null) {
-            return;
+    private List<Issue> validateModeAndInteraction(ModeType modeType, FHIRResourceHelpers resourceHelper, String resourceType,
+            FHIROperationContext operationContext, String logicalId) throws FHIROperationException {
+        if (modeType == null) {
+            return Collections.emptyList();
         }
-        // Validate an interaction for a specified resource type.
-        if ((modetype == ModeType.CREATE  
-                || modetype == ModeType.UPDATE 
-                || modetype == ModeType.DELETE)
-                && resourceType != null) {
-            FHIRResourceHelpers.Interaction interaction = FHIRResourceHelpers.Interaction.from(modetype.value());
-            resourceHelper.validateInteraction(interaction, resourceType);
+
+        // Validate if modes update and delete are only be used when the operation is invoked at the resource instance level
+        if (operationContext.getType() == FHIROperationContext.Type.RESOURCE_TYPE &&
+                (modeType == ModeType.UPDATE || modeType == ModeType.DELETE)) {
+
+            throw buildExceptionWithIssue(IssueSeverity.ERROR, IssueType.NOT_SUPPORTED,
+                    "Modes update and delete can only be used when the operation is invoked at the resource instance level.", null);
         }
-        // Validate if persistence layer implementation supports update/create mode if mode = create.
-        if (operationContext != null && operationContext.getType() == FHIROperationContext.Type.INSTANCE 
-                && modetype == ModeType.CREATE) {
-            validateUpdateCreateEnabled(modetype, resourceType, operationContext);
-        }
-        // Validate if persistence layer implementation supports update/create mode if mode = update but the resource does not exist yet in the DB.
-        if (operationContext != null && operationContext.getType() == FHIROperationContext.Type.INSTANCE 
-                && modetype == ModeType.UPDATE) {
-            Resource existingResource = resourceHelper.doRead(resourceType, logicalId).getResource();
-            if (existingResource == null) {
-                validateUpdateCreateEnabled(modetype, resourceType, operationContext);    
+
+        List<Issue> issues = new ArrayList<>();
+
+        // Validate the interaction type is allowed for the specified resource type.
+        if ((modeType == ModeType.CREATE || modeType == ModeType.UPDATE || modeType == ModeType.DELETE)) {
+            FHIRResourceHelpers.Interaction interaction = FHIRResourceHelpers.Interaction.from(modeType.value());
+            try {
+                resourceHelper.validateInteraction(interaction, resourceType);
+            } catch (FHIROperationException e) {
+                issues.addAll(e.getIssues());
             }
         }
-        // Validate if modes update and delete are only be used when the operation is invoked at the resource instance level
-        if (operationContext != null && operationContext.getType() == FHIROperationContext.Type.RESOURCE_TYPE && 
-                (modetype == ModeType.UPDATE || modetype == ModeType.DELETE)) {
-            
-            throw buildExceptionWithIssue(IssueSeverity.ERROR, IssueType.NOT_SUPPORTED, "Modes update and delete can only be used when the operation is invoked at the resource instance level.", null);
-        }
+
+        return issues;
     }
 
     /**
      * This method when invoked checks if the persistence layer implementation supports update/create.
-     * If the persistence layer implementation does not support update/create a FHIROperationException with issue is thrown.
+     * If the persistence layer implementation does not support update/create, an issue is added to the list of issues that was passed.
      * @param modetype
      * @param resourceType
      * @param operationContext
+     * @param issues
      * @throws FHIROperationException
      */
-    private void validateUpdateCreateEnabled(ModeType modetype, String resourceType, FHIROperationContext operationContext) throws FHIROperationException {
+    private void validateUpdateCreateEnabled(ModeType modetype, String resourceType, FHIROperationContext operationContext, List<Issue> issues)
+            throws FHIROperationException {
         FHIRPersistence persistence =
                 (FHIRPersistence) operationContext.getProperty(FHIROperationContext.PROPNAME_PERSISTENCE_IMPL);
         if (!persistence.isUpdateCreateEnabled()) {
-            throw buildExceptionWithIssue(IssueSeverity.ERROR, IssueType.NOT_SUPPORTED, "Resource " + modetype.value() +  ", of type '"
-                    + resourceType + "', is not supported.", null);  
+            issues.add(FHIRUtil.buildOperationOutcomeIssue(IssueSeverity.ERROR, IssueType.NOT_SUPPORTED,
+                    "Resource " + modetype.value() +  ", of type '" + resourceType + "', is not supported."));
         }
     }
 
     /**
-     * If the mode parameter is not null, this method validates if a resource validation mode code is valid and
-     * returns valid resource validation mode code from ModeType enum.
-     * If mode parameter is null this method returns null.
-     * If mode parameter is not valid this method throws FHIROperationException with issues.
+     * If the mode parameter is not null, this method validates that the resource validation mode code
+     * is valid and returns the corresponding value from the ModeType enum.
      * @param modeParameter resource validation mode code
      * @return The corresponding ModeType or null if a null value was passed
-     * @throws FHIROperationException
+     * @throws FHIROperationException If the mode parameter has an invalid value
      */
     private ModeType getModeType(Parameter modeParameter) throws FHIROperationException {
-        if (modeParameter != null && modeParameter.getValue() != null) {
-            ModeType modetype;
-            try {
-                modetype =  ModeType.from(modeParameter.getValue().as(Code.class).getValue());
-            } catch (IllegalArgumentException e) {
-                String msg = "'" + modeParameter.getValue().as(Code.class).getValue() + "' is not a valid resource validation mode";
-                throw buildExceptionWithIssue(IssueSeverity.ERROR, IssueType.NOT_SUPPORTED, msg, null);
-            }
-            return modetype;
-            
+        if (modeParameter == null || modeParameter.getValue() == null) {
+            return null;
         }
-        return null;
+
+        ModeType modetype;
+        try {
+            modetype =  ModeType.from(modeParameter.getValue().as(Code.class).getValue());
+        } catch (IllegalArgumentException e) {
+            String msg = "'" + modeParameter.getValue().as(Code.class).getValue() + "' is not a valid resource validation mode";
+            throw buildExceptionWithIssue(IssueSeverity.ERROR, IssueType.NOT_SUPPORTED, msg, null);
+        }
+        return modetype;
     }
-    
-    
+
+
     /**
      * Validate if the persistence layer implementation supports the "delete" operation.
      *
-     * @param type the resource type 
+     * @param type the resource type
      * @param id the resource logical ID
      * @param operationContext the FHIROperationContext associated with the request
      * @return A list of validation errors and warnings
@@ -222,7 +230,7 @@ public class ValidateOperation extends AbstractOperation {
         }
         return warnings;
     }
-    
+
     /**
      * Method to build the OperationOutcome error response
      * @param severity the issue severity
@@ -236,53 +244,100 @@ public class ValidateOperation extends AbstractOperation {
         OperationOutcome.Issue ooi = FHIRUtil.buildOperationOutcomeIssue(severity, issueType, msg);
         return new FHIROperationException(msg, cause).withIssue(ooi);
     }
-    
+
     /**
-     * Method to validate the resource parameter. The below validations are performed by this method.
-     * 1. if $validate is invoked at instance level and mode = create, check if the resource already exists.
-     * 2. resource parameter must be present unless the mode is "delete" (or "profile" per https://jira.hl7.org/browse/FHIR-37998)
-     * 3. if mode=profile AND no resource parameter value is provided then the resource at this id is read and validated against the nominated profile
+     * Get the resource from the input resource parameter or from the database if mode=profile and invoked at instance level.
      * @param operationContext - the FHIROperationContext associated with the request
      * @param logicalId - the logical id of the FHIR resource
      * @param resourceHelper - Resource operation provider for loading related Library resources
      * @param resourceParameter - the input resource parameter
      * @param resourceType  - a valid resource type string
      * @param modeType - a valid resource validation mode code
-     * @return Resource - a FHIR Resource object
-     * @throws Exception
-     * @throws FHIROperationException
+     * @return Resource - one of:
+     *      1. the value of the resource parameter
+     *      2. the resource that was read if mode=profile and no resource parameter value is provided; or
+     *      3. null if mode=delete
+     * @throws FHIROperationException if either:
+     *      1. the mode is "delete" (or "profile" per https://jira.hl7.org/browse/FHIR-37998) and the resource parameter is not present; or
+     *      2. the mode is "profile" but a resource with the passed logicalId doesn't exist (or couldn't be read)
      */
-    private Resource validateResource(FHIROperationContext operationContext, String logicalId, FHIRResourceHelpers resourceHelper, Parameter resourceParameter,
-        String resourceType, ModeType modeType) throws Exception, FHIROperationException {
+    private Resource getResource(FHIROperationContext operationContext, String logicalId, FHIRResourceHelpers resourceHelper, Parameter resourceParameter,
+            String resourceType, ModeType modeType) throws Exception, FHIROperationException {
         Resource resource = null;
-        // if $validate is invoked at instance level and mode = create, check if the resource already exists. 
-        if (operationContext != null && operationContext.getType() == FHIROperationContext.Type.INSTANCE 
-                && modeType == ModeType.CREATE) {
-            Resource existingResource = resourceHelper.doRead(resourceType, logicalId).getResource();
-            if (existingResource != null) {
-                throw buildExceptionWithIssue(IssueSeverity.ERROR, IssueType.NOT_SUPPORTED, resourceType + " with id '" + logicalId + "' already exists", null);
-            }
-        }
+
         // resource parameter must be present unless the mode is "delete" (or "profile" per https://jira.hl7.org/browse/FHIR-37998)
-        if (resourceParameter == null 
-                && (modeType == null 
-                || modeType == ModeType.CREATE 
-                || modeType == ModeType.UPDATE)) {
-            throw buildExceptionWithIssue(IssueSeverity.ERROR, IssueType.INVALID, "Input parameter 'resource' must be present unless the mode is 'delete' or 'profile'", null);
-        }
-        // if mode=profile AND no resource parameter value is provided then the resource at this id is read and validated against the nominated profile
-        if (resourceParameter == null && operationContext != null && operationContext.getType() == FHIROperationContext.Type.INSTANCE 
-                && modeType == ModeType.PROFILE) {
-            resource = resourceHelper.doRead(resourceType, logicalId).getResource();
-            if (resource == null) {
-                throw buildExceptionWithIssue(IssueSeverity.ERROR, IssueType.INVALID, resourceType + " with id '" + logicalId + "' does not exist", null);
+        if (resourceParameter == null) {
+            if (modeType == null || modeType == ModeType.CREATE || modeType == ModeType.UPDATE) {
+                throw buildExceptionWithIssue(IssueSeverity.ERROR, IssueType.INVALID,
+                        "Input parameter 'resource' must be present unless the mode is 'delete' or 'profile'", null);
             }
-        }
-        
-        if (resourceParameter != null) {
+
+            // if mode=profile AND no resource parameter value is provided
+            // then use resource at this id is read and validated against the nominated profile
+            if (operationContext != null && operationContext.getType() == FHIROperationContext.Type.INSTANCE
+                    && modeType == ModeType.PROFILE) {
+                resource = resourceHelper.doRead(resourceType, logicalId).getResource();
+                if (resource == null) {
+                    throw buildExceptionWithIssue(IssueSeverity.ERROR, IssueType.NOT_FOUND,
+                            resourceType + " with id '" + logicalId + "' does not exist", null);
+                }
+            }
+        } else {
             resource = resourceParameter.getResource();
         }
+
         return resource;
     }
-    
+
+    /**
+     * When $validate is invoked at the instance level, we need to perform some additional validations:
+     * <ul>
+     * <li>if mode = create or update, check that the id of the passed resource matches the id in the URL
+     * <li>if mode = create, check if the resource already exists.
+     * <li>if mode = create or mode = update and the resource doesn't exist, check that "create-on-update" is enabled
+     * </ul>
+     * @param operationContext - the FHIROperationContext associated with the request
+     * @param logicalId - the logical id of the FHIR resource
+     * @param resourceHelper - Resource operation provider for loading related Library resources
+     * @param resource - the resource to be validated
+     * @param resourceType  - a valid resource type string
+     * @param modeType - a valid resource validation mode code
+     * @return List<Issue> - a non-null, possibly-empty list of issues that indicate why the resource is not valid for the passed modeType
+     */
+    private List<Issue> validateInstanceLevelInvoke(FHIROperationContext operationContext, String logicalId, FHIRResourceHelpers resourceHelper,
+            Resource resource, String resourceType, ModeType modeType) throws Exception, FHIROperationException {
+        List<Issue> issues = new ArrayList<>();
+
+        if (modeType == ModeType.CREATE || modeType == ModeType.UPDATE) {
+            // if mode = create or update, check that the id of the passed resource matches the id in the URL
+            validateResourceId(logicalId, resource, issues);
+
+            boolean resourceExists = resourceHelper.doRead(resourceType, logicalId).getResource() != null;
+
+            // if mode = create, check if the resource already exists
+            if (modeType == ModeType.CREATE && resourceExists) {
+                issues.add(FHIRUtil.buildOperationOutcomeIssue(IssueSeverity.ERROR, IssueType.INVALID,
+                        resourceType + " with id '" + logicalId + "' already exists"));
+            }
+
+            // if mode = create or mode = update and the resource doesn't exist yet,
+            // check if the persistence layer implementation supports update/create mode
+            if (modeType == ModeType.CREATE || !resourceExists) {
+                validateUpdateCreateEnabled(modeType, resourceType, operationContext, issues);
+            }
+        }
+
+        return issues;
+    }
+
+    private void validateResourceId(String logicalId, Resource resource, List<Issue> issues) {
+        String resourceId = resource.getId();
+        if (resourceId == null) {
+            issues.add(FHIRUtil.buildOperationOutcomeIssue(IssueSeverity.ERROR, IssueType.INVALID,
+                    "Input resource 'id' field is not set"));
+        } else if (!resourceId.equals(logicalId)) {
+            issues.add(FHIRUtil.buildOperationOutcomeIssue(IssueSeverity.ERROR, IssueType.INVALID,
+                    "Input resource 'id' field must match the 'id' path parameter."));
+        }
+    }
 }

--- a/operation/fhir-operation-validate/src/main/java/org/linuxforhealth/fhir/operation/validate/ValidateOperation.java
+++ b/operation/fhir-operation-validate/src/main/java/org/linuxforhealth/fhir/operation/validate/ValidateOperation.java
@@ -274,7 +274,7 @@ public class ValidateOperation extends AbstractOperation {
 
             // if mode=profile AND no resource parameter value is provided
             // then use resource at this id is read and validated against the nominated profile
-            if (operationContext != null && operationContext.getType() == FHIROperationContext.Type.INSTANCE
+            if (operationContext.getType() == FHIROperationContext.Type.INSTANCE
                     && modeType == ModeType.PROFILE) {
                 resource = resourceHelper.doRead(resourceType, logicalId).getResource();
                 if (resource == null) {
@@ -320,7 +320,7 @@ public class ValidateOperation extends AbstractOperation {
                         resourceType + " with id '" + logicalId + "' already exists"));
             }
 
-            // if mode = create or mode = update and the resource doesn't exist yet,
+            // if "mode = create" or if "mode = update and the resource doesn't exist yet",
             // check if the persistence layer implementation supports update/create mode
             if (modeType == ModeType.CREATE || !resourceExists) {
                 validateUpdateCreateEnabled(modeType, resourceType, operationContext, issues);

--- a/operation/fhir-operation-validate/src/test/java/org/linuxforhealth/fhir/operation/validate/ValidateOperationTest.java
+++ b/operation/fhir-operation-validate/src/test/java/org/linuxforhealth/fhir/operation/validate/ValidateOperationTest.java
@@ -66,7 +66,8 @@ public class ValidateOperationTest {
             Parameters input = Parameters.builder()
                     .build();
 
-            validateOperation.doInvoke(null, null, null, null, input, resourceHelper, null);
+            FHIROperationContext operationContext = mock(FHIROperationContext.class);
+            validateOperation.doInvoke(operationContext, Patient.class, null, null, input, resourceHelper, null);
             fail();
         } catch (Exception e) {
             assertEquals(e.getMessage(), "Input parameter 'resource' must be present unless the mode is 'delete' or 'profile'");
@@ -96,16 +97,17 @@ public class ValidateOperationTest {
                     .severity(IssueSeverity.INFORMATION)
                     .code(IssueType.INFORMATIONAL)
                     .details(CodeableConcept.builder()
-                        .text(string("All OK"))
+                        .text("All OK")
                         .build())
                     .build();
 
-            Parameters output = validateOperation.doInvoke(null, null, null, null, input, resourceHelper, null);
+            FHIROperationContext operationContext = mock(FHIROperationContext.class);
+            Parameters output = validateOperation.doInvoke(operationContext, Patient.class, null, null, input, resourceHelper, null);
             OperationOutcome oo = output.getParameter().get(0).getResource().as(OperationOutcome.class);
             assertEquals(oo.getIssue().size(), 1);
             assertEquals(oo.getIssue().get(0), expectedOutput);
         } catch (Exception e) {
-            fail();
+            fail("unexpected exception: " + e);
         }
     }
 
@@ -135,17 +137,18 @@ public class ValidateOperationTest {
                     .severity(IssueSeverity.WARNING)
                     .code(IssueType.NOT_SUPPORTED)
                     .details(CodeableConcept.builder()
-                        .text(string("Profile 'unsupported' is not supported"))
+                        .text("Profile 'unsupported' is not supported")
                         .build())
-                    .expression(string("Patient"))
+                    .expression("Patient")
                     .build();
 
-            Parameters output = validateOperation.doInvoke(null, null, null, null, input, resourceHelper, null);
+            FHIROperationContext operationContext = mock(FHIROperationContext.class);
+            Parameters output = validateOperation.doInvoke(operationContext, Patient.class, null, null, input, resourceHelper, null);
             OperationOutcome oo = output.getParameter().get(0).getResource().as(OperationOutcome.class);
             assertEquals(oo.getIssue().size(), 1);
             assertEquals(oo.getIssue().get(0), expectedOutput);
         } catch (Exception e) {
-            fail();
+            fail("unexpected exception: " + e);
         }
     }
 
@@ -180,16 +183,18 @@ public class ValidateOperationTest {
                     .severity(IssueSeverity.ERROR)
                     .code(IssueType.BUSINESS_RULE)
                     .details(CodeableConcept.builder()
-                        .text(string("A required profile was not specified. Resources of type 'Patient' must declare conformance to at least one of the following profiles: [atLeastOne]"))
+                        .text("A required profile was not specified. Resources of type 'Patient' must declare conformance "
+                                + "to at least one of the following profiles: [atLeastOne]")
                         .build())
                     .build();
 
-            Parameters output = validateOperation.doInvoke(null, null, null, null, input, resourceHelper, null);
+            FHIROperationContext operationContext = mock(FHIROperationContext.class);
+            Parameters output = validateOperation.doInvoke(operationContext, Patient.class, null, null, input, resourceHelper, null);
             OperationOutcome oo = output.getParameter().get(0).getResource().as(OperationOutcome.class);
             assertEquals(oo.getIssue().size(), 1);
             assertEquals(oo.getIssue().get(0), expectedOutput);
         } catch (Exception e) {
-            fail();
+            fail("unexpected exception: " + e);
         }
     }
 
@@ -224,16 +229,18 @@ public class ValidateOperationTest {
                     .severity(IssueSeverity.ERROR)
                     .code(IssueType.BUSINESS_RULE)
                     .details(CodeableConcept.builder()
-                        .text(string("A profile was specified which is not allowed. Resources of type 'Patient' are not allowed to declare conformance to any of the following profiles: [notAllowed]"))
+                        .text("A profile was specified which is not allowed. Resources of type 'Patient' are not allowed "
+                                + "to declare conformance to any of the following profiles: [notAllowed]")
                         .build())
                     .build();
 
-            Parameters output = validateOperation.doInvoke(null, null, null, null, input, resourceHelper, null);
+            FHIROperationContext operationContext = mock(FHIROperationContext.class);
+            Parameters output = validateOperation.doInvoke(operationContext, Patient.class, null, null, input, resourceHelper, null);
             OperationOutcome oo = output.getParameter().get(0).getResource().as(OperationOutcome.class);
             assertEquals(oo.getIssue().size(), 1);
             assertEquals(oo.getIssue().get(0), expectedOutput);
         } catch (Exception e) {
-            fail();
+            fail("unexpected exception: " + e);
         }
     }
 
@@ -268,23 +275,24 @@ public class ValidateOperationTest {
                     .severity(IssueSeverity.ERROR)
                     .code(IssueType.NOT_SUPPORTED)
                     .details(CodeableConcept.builder()
-                        .text(string("Profile 'unsupported' is not supported"))
+                        .text("Profile 'unsupported' is not supported")
                         .build())
-                    .expression(string("Patient"))
+                    .expression("Patient")
                     .build();
 
-            Parameters output = validateOperation.doInvoke(null, null, null, null, input, resourceHelper, null);
+            FHIROperationContext operationContext = mock(FHIROperationContext.class);
+            Parameters output = validateOperation.doInvoke(operationContext, Patient.class, null, null, input, resourceHelper, null);
             OperationOutcome oo = output.getParameter().get(0).getResource().as(OperationOutcome.class);
             assertEquals(oo.getIssue().size(), 1);
             assertEquals(oo.getIssue().get(0), expectedOutput);
         } catch (Exception e) {
-            fail();
+            fail("unexpected exception: " + e);
         }
     }
-    
+
     /**
      * Test resource-instance level validate operation when the resource with the input logicalID is available in the database.
-     * @throws Exception 
+     * @throws Exception
      */
     @Test
     public void testResourceInstanceLevelValidate() throws Exception {
@@ -297,13 +305,12 @@ public class ValidateOperationTest {
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
         SingleResourceResult result = mock(SingleResourceResult.class);
 
-     // mock and return a resource when resourceHelper.doRead() is invoked from validateOperation.doInvoke
+        // mock and return a resource when resourceHelper.doRead() is invoked from validateOperation.doInvoke
         when(result.isSuccess()).thenReturn(true);
         when(result.getResource()).thenReturn(patient);
         when(resourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> result);
-        
-        FHIROperationContext operationContext =
-                FHIROperationContext.createInstanceOperationContext("validate");
+
+        FHIROperationContext operationContext = opInstanceContextWithMockPersistence(true);
         Parameters input =  Parameters.builder()
                 .parameter(Parameter.builder()
                     .name("resource")
@@ -315,12 +322,12 @@ public class ValidateOperationTest {
                         .build())
                     .build())
                 .build();
-        
+
         Issue expectedOutput = Issue.builder()
                     .severity(IssueSeverity.INFORMATION)
                     .code(IssueType.INFORMATIONAL)
                     .details(CodeableConcept.builder()
-                        .text(string("All OK"))
+                        .text("All OK")
                         .build())
                     .build();
         Parameters output = validateOperation.doInvoke(operationContext, Patient.class, "test", null, input, resourceHelper, null);
@@ -328,33 +335,35 @@ public class ValidateOperationTest {
         assertEquals(operationOutcome.getIssue().size(), 1);
         assertEquals(operationOutcome.getIssue().get(0), expectedOutput);
     }
-    
+
     /**
-     * Test resource-instance level validate operation when the resource with the input logicalID is not available in the database.
-     * @throws Exception 
+     * Test resource-instance level validate operation when the resource with the input logicalId already exists in the database.
+     * @throws Exception
      */
-    @Test(expectedExceptions = { FHIROperationException.class } , expectedExceptionsMessageRegExp  = ".*Patient with id '1' already exists*")
+    @Test
     public void testResourceInstanceLevelValidateForAlreadyExistingResource() throws Exception {
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
         SingleResourceResult result = mock(SingleResourceResult.class);
-        Patient patient = Patient.builder().id("test")
+        Patient patient = Patient.builder()
+                .id("1")
                 .text(Narrative.builder()
                     .div(Xhtml.of("<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"))
                     .status(NarrativeStatus.GENERATED)
                     .build())
                 .build();
-        
+
         // mock and return null when resourceHelper.doRead() is invoked from validateOperation.doInvoke
         when(result.isSuccess()).thenReturn(false);
         when(result.getResource()).thenReturn(patient);
         when(resourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> result);
-        
-        FHIROperationContext operationContext =
-                FHIROperationContext.createInstanceOperationContext("validate");
+
+        FHIROperationContext operationContext = opInstanceContextWithMockPersistence(true);
+
         Parameters input = Parameters.builder()
                 .parameter(Parameter.builder()
                     .name("resource")
                     .resource(Patient.builder()
+                        .id("1")
                         .text(Narrative.builder()
                             .div(Xhtml.of("<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"))
                             .status(NarrativeStatus.GENERATED)
@@ -367,13 +376,25 @@ public class ValidateOperationTest {
                         .build())
                 .build();
 
-        validateOperation.doInvoke(operationContext, Patient.class, "1", null, input, resourceHelper, null);
+        Issue expectedOutput = Issue.builder()
+                .severity(IssueSeverity.ERROR)
+                .code(IssueType.INVALID)
+                .details(CodeableConcept.builder()
+                    .text("Patient with id '1' already exists")
+                    .build())
+                .build();
+
+        Parameters output = validateOperation.doInvoke(operationContext, Patient.class, "1", null, input, resourceHelper, null);
+
+        OperationOutcome operationOutcome = output.getParameter().get(0).getResource().as(OperationOutcome.class);
+        assertEquals(operationOutcome.getIssue().size(), 1);
+        assertEquals(operationOutcome.getIssue().get(0), expectedOutput);
     }
-    
+
     /**
-     * Test validate operation with a invalid mode type code input. 
+     * Test validate operation with a invalid mode type code input.
      * The validate operation will fail with FHIROperationException
-     * @throws FHIROperationException 
+     * @throws FHIROperationException
      */
     @Test(expectedExceptions = { FHIROperationException.class } , expectedExceptionsMessageRegExp  = ".*'random' is not a valid resource validation mode*")
     public void testInvalidValidModeTypes() throws FHIROperationException {
@@ -392,19 +413,20 @@ public class ValidateOperationTest {
                             .value(Code.of("random"))
                             .build())
                     .build();
-           validateOperation.doInvoke(null, null, null, null, input, resourceHelper, null);
-        
+
+           FHIROperationContext operationContext = mock(FHIROperationContext.class);
+           validateOperation.doInvoke(operationContext, Patient.class, null, null, input, resourceHelper, null);
+
     }
-    
+
     /**
-     * Test validate operation with delete mode type code. 
-     * Validate the outcome when the persistence layer implementation does not support the "delete" operation 
-     *  
+     * Test validate operation with delete mode type code.
+     * Validate the outcome when the persistence layer implementation does not support the "delete" operation
+     *
      */
     @Test
     public void testValidateOperationDeleteNotSupported() throws FHIROperationException {
-        
-           FHIRPersistence persistence = Mockito.mock(FHIRPersistence.class);
+
            Parameters input = Parameters.builder()
                     .parameter(Parameter.builder()
                         .name("resource")
@@ -420,206 +442,285 @@ public class ValidateOperationTest {
                             .value(Code.of("delete"))
                             .build())
                     .build();
-            FHIROperationContext operationContext =
-                    FHIROperationContext.createInstanceOperationContext("validate");
-            operationContext.setProperty(FHIROperationContext.PROPNAME_PERSISTENCE_IMPL, persistence);
-            
-            // mock the persistence layer implementation not to support the "delete" operation
-            when(persistence.isDeleteSupported()).thenReturn(false);
-            
-            Issue expectedOutput = Issue.builder()
-                    .severity(IssueSeverity.ERROR)
-                    .code(IssueType.NOT_SUPPORTED)
-                    .details(CodeableConcept.builder()
-                        .text(string("Resource deletion, of type 'Patient', with id '1', is not supported."))
-                        .build())
-                    .build();
-            Parameters output = validateOperation.doInvoke(operationContext, Patient.class, "1", null, input, resourceHelper, null);
-            OperationOutcome operationOutcome = output.getParameter().get(0).getResource().as(OperationOutcome.class);
-            assertEquals(operationOutcome.getIssue().size(), 1);
-            assertEquals(operationOutcome.getIssue().get(0), expectedOutput);
-        
+
+           // mock the persistence layer implementation not to support the "delete" operation
+           FHIROperationContext operationContext = opInstanceContextWithMockPersistence(true, false);
+
+           Issue expectedOutput = Issue.builder()
+                   .severity(IssueSeverity.ERROR)
+                   .code(IssueType.NOT_SUPPORTED)
+                   .details(CodeableConcept.builder()
+                           .text("Resource deletion, of type 'Patient', with id '1', is not supported.")
+                           .build())
+                   .build();
+           Parameters output = validateOperation.doInvoke(operationContext, Patient.class, "1", null, input, resourceHelper, null);
+           OperationOutcome operationOutcome = output.getParameter().get(0).getResource().as(OperationOutcome.class);
+           assertEquals(operationOutcome.getIssue().size(), 1);
+           assertEquals(operationOutcome.getIssue().get(0), expectedOutput);
     }
-    
+
     /**
-     * Test validate operation with delete mode type code. 
-     * Validate the outcome when the persistence layer implementation supports the "delete" operation 
-     * 
+     * Test validate operation with delete mode type code.
+     * Validate the outcome when the persistence layer implementation supports the "delete" operation
+     *
      */
     @Test
     public void testValidateOperationDeleteSupported() throws FHIROperationException {
-        
-        FHIRPersistence persistence = Mockito.mock(FHIRPersistence.class);
-            Parameters input = Parameters.builder()
-                    .parameter(Parameter.builder()
-                        .name("resource")
-                        .resource(Patient.builder()
-                            .meta(Meta.builder()
-                                .profile(Canonical.of("atLeastOne"), Canonical.of("notAllowed"))
-                                .build())
-                            .text(Narrative.builder()
-                                .div(Xhtml.of("<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"))
-                                .status(NarrativeStatus.GENERATED)
-                                .build())
+
+        Parameters input = Parameters.builder()
+                .parameter(Parameter.builder()
+                    .name("resource")
+                    .resource(Patient.builder()
+                        .meta(Meta.builder()
+                            .profile(Canonical.of("atLeastOne"), Canonical.of("notAllowed"))
                             .build())
-                        .build(),
-                        Parameter.builder()
-                            .name("mode")
-                            .value(Code.of("delete"))
+                        .text(Narrative.builder()
+                            .div(Xhtml.of("<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"))
+                            .status(NarrativeStatus.GENERATED)
                             .build())
-                    .build();
-            FHIROperationContext operationContext =
-                    FHIROperationContext.createInstanceOperationContext("validate");
-            operationContext.setProperty(FHIROperationContext.PROPNAME_PERSISTENCE_IMPL, persistence);
-            
-            // mock the persistence layer implementation to support the "delete" operation 
-            when(persistence.isDeleteSupported()).thenReturn(true);
-            
-            Issue expectedOutput = Issue.builder()
-                    .severity(IssueSeverity.INFORMATION)
-                    .code(IssueType.INFORMATIONAL)
-                    .details(CodeableConcept.builder()
-                        .text(string("All OK"))
                         .build())
-                    .build();
-            
-            Parameters output = validateOperation.doInvoke(operationContext, Patient.class, "1", null, input, resourceHelper, null);
-            
-            OperationOutcome operationOutcome = output.getParameter().get(0).getResource().as(OperationOutcome.class);
-            assertEquals(operationOutcome.getIssue().size(), 1);
-            assertEquals(operationOutcome.getIssue().get(0), expectedOutput); 
-        
+                    .build(),
+                    Parameter.builder()
+                        .name("mode")
+                        .value(Code.of("delete"))
+                        .build())
+                .build();
+
+        // mock the persistence layer implementation to support the "delete" operation
+        FHIROperationContext operationContext = opInstanceContextWithMockPersistence(true, true);
+
+        Issue expectedOutput = Issue.builder()
+                .severity(IssueSeverity.INFORMATION)
+                .code(IssueType.INFORMATIONAL)
+                .details(CodeableConcept.builder()
+                    .text("All OK")
+                    .build())
+                .build();
+
+        Parameters output = validateOperation.doInvoke(operationContext, Patient.class, "1", null, input, resourceHelper, null);
+
+        OperationOutcome operationOutcome = output.getParameter().get(0).getResource().as(OperationOutcome.class);
+        assertEquals(operationOutcome.getIssue().size(), 1);
+        assertEquals(operationOutcome.getIssue().get(0), expectedOutput);
     }
-    
-    
+
+
     /**
      * Test validate operation with update mode type code and  "update/create" enabled.
-     * Validate the outcome when the persistence layer implementation supports the "update/create" operation  
-     * @throws Exception 
-     * 
+     * Validate the outcome when the persistence layer implementation supports the "update/create" operation
+     * @throws Exception
      */
     @Test
     public void testValidateOperationWithUpdateCreateEnabled() throws Exception {
-        FHIRPersistence persistence = Mockito.mock(FHIRPersistence.class);
-            Parameters input = Parameters.builder()
-                    .parameter(Parameter.builder()
-                        .name("resource")
-                        .resource(Patient.builder()
-                            .text(Narrative.builder()
-                                .div(Xhtml.of("<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"))
-                                .status(NarrativeStatus.GENERATED)
-                                .build())
+        Parameters input = Parameters.builder()
+                .parameter(Parameter.builder()
+                    .name("resource")
+                    .resource(Patient.builder()
+                        .id("1")
+                        .text(Narrative.builder()
+                            .div(Xhtml.of("<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"))
+                            .status(NarrativeStatus.GENERATED)
                             .build())
-                        .build(),
-                        Parameter.builder()
-                            .name("mode")
-                            .value(Code.of("update"))
-                            .build())
-                    .build();
-            FHIROperationContext operationContext =
-                    FHIROperationContext.createInstanceOperationContext("validate");
-            operationContext.setProperty(FHIROperationContext.PROPNAME_PERSISTENCE_IMPL, persistence);
-            
-            Issue expectedOutput = Issue.builder()
-                    .severity(IssueSeverity.INFORMATION)
-                    .code(IssueType.INFORMATIONAL)
-                    .details(CodeableConcept.builder()
-                        .text(string("All OK"))
                         .build())
-                    .build();
-            // mock the persistence layer implementation to support the "update/create" operation 
-            when(persistence.isUpdateCreateEnabled()).thenReturn(true);
-           
-            FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-            SingleResourceResult result = mock(SingleResourceResult.class);
+                    .build(),
+                    Parameter.builder()
+                        .name("mode")
+                        .value(Code.of("update"))
+                        .build())
+                .build();
+        FHIROperationContext operationContext = opInstanceContextWithMockPersistence(true);
 
-         // mock and return a resource when resourceHelper.doRead() is invoked from validateOperation.doInvoke
-            when(result.isSuccess()).thenReturn(true);
-            when(result.getResource()).thenReturn(null);
-            when(resourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> result);
-            Parameters output = validateOperation.doInvoke(operationContext, Patient.class, "1", null, input, resourceHelper, null);
-            
-            OperationOutcome operationOutcome = output.getParameter().get(0).getResource().as(OperationOutcome.class);
-            assertEquals(operationOutcome.getIssue().size(), 1);
-            assertEquals(operationOutcome.getIssue().get(0), expectedOutput);
-        
+        Issue expectedOutput = Issue.builder()
+                .severity(IssueSeverity.INFORMATION)
+                .code(IssueType.INFORMATIONAL)
+                .details(CodeableConcept.builder()
+                    .text("All OK")
+                    .build())
+                .build();
+
+        FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
+        SingleResourceResult<?> result = mock(SingleResourceResult.class);
+
+        // mock and return a resource when resourceHelper.doRead() is invoked from validateOperation.doInvoke
+        when(result.isSuccess()).thenReturn(true);
+        when(result.getResource()).thenReturn(null);
+        when(resourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> result);
+        Parameters output = validateOperation.doInvoke(operationContext, Patient.class, "1", null, input, resourceHelper, null);
+
+        OperationOutcome operationOutcome = output.getParameter().get(0).getResource().as(OperationOutcome.class);
+        assertEquals(operationOutcome.getIssue().size(), 1);
+        assertEquals(operationOutcome.getIssue().get(0), expectedOutput);
     }
-    
+
+    /**
+     * Test validate operation at the instance level with mode=update where the passed resource
+     * is missing the Resource.id element.
+     * @throws Exception
+     */
+    @Test
+    public void testValidateOperationWithMissingId() throws Exception {
+        Parameters input = Parameters.builder()
+                .parameter(Parameter.builder()
+                    .name("resource")
+                    .resource(Patient.builder()
+                        .text(Narrative.builder()
+                            .div(Xhtml.of("<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"))
+                            .status(NarrativeStatus.GENERATED)
+                            .build())
+                        .build())
+                    .build(),
+                    Parameter.builder()
+                        .name("mode")
+                        .value(Code.of("update"))
+                        .build())
+                .build();
+        FHIROperationContext operationContext = opInstanceContextWithMockPersistence(true);
+
+        Issue expectedOutput = Issue.builder()
+                .severity(IssueSeverity.ERROR)
+                .code(IssueType.INVALID)
+                .details(CodeableConcept.builder()
+                    .text("Input resource 'id' field is not set")
+                    .build())
+                .build();
+
+        FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
+        SingleResourceResult<?> result = mock(SingleResourceResult.class);
+
+        // mock and return a resource when resourceHelper.doRead() is invoked from validateOperation.doInvoke
+        when(result.isSuccess()).thenReturn(true);
+        when(result.getResource()).thenReturn(null);
+        when(resourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> result);
+        Parameters output = validateOperation.doInvoke(operationContext, Patient.class, "1", null, input, resourceHelper, null);
+
+        OperationOutcome operationOutcome = output.getParameter().get(0).getResource().as(OperationOutcome.class);
+        assertEquals(operationOutcome.getIssue().size(), 1);
+        assertEquals(operationOutcome.getIssue().get(0), expectedOutput);
+    }
+
+    /**
+     * Test validate operation at the instance level with mode=update where the passed resource
+     * has a Resource.id element which doesn't match the id passed in the URL.
+     * @throws Exception
+     */
+    @Test
+    public void testValidateOperationWithWrongId() throws Exception {
+        Parameters input = Parameters.builder()
+                .parameter(Parameter.builder()
+                    .name("resource")
+                    .resource(Patient.builder()
+                        .id("xyz")
+                        .text(Narrative.builder()
+                            .div(Xhtml.of("<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"))
+                            .status(NarrativeStatus.GENERATED)
+                            .build())
+                        .build())
+                    .build(),
+                    Parameter.builder()
+                        .name("mode")
+                        .value(Code.of("update"))
+                        .build())
+                .build();
+        FHIROperationContext operationContext = opInstanceContextWithMockPersistence(true);
+
+        Issue expectedOutput = Issue.builder()
+                .severity(IssueSeverity.ERROR)
+                .code(IssueType.INVALID)
+                .details(CodeableConcept.builder()
+                    .text("Input resource 'id' field must match the 'id' path parameter.")
+                    .build())
+                .build();
+
+        FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
+        SingleResourceResult<?> result = mock(SingleResourceResult.class);
+
+        // mock and return a resource when resourceHelper.doRead() is invoked from validateOperation.doInvoke
+        when(result.isSuccess()).thenReturn(true);
+        when(result.getResource()).thenReturn(null);
+        when(resourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> result);
+        Parameters output = validateOperation.doInvoke(operationContext, Patient.class, "1", null, input, resourceHelper, null);
+
+        OperationOutcome operationOutcome = output.getParameter().get(0).getResource().as(OperationOutcome.class);
+        assertEquals(operationOutcome.getIssue().size(), 1);
+        assertEquals(operationOutcome.getIssue().get(0), expectedOutput);
+    }
+
     /**
      * Test validate operation with update mode type code and "update/create" disabled.
-     * Validate the outcome when the persistence layer implementation does not support the "update/create" operation  
-     * @throws Exception 
-     * 
+     * Validate the outcome when the persistence layer implementation does not support the "update/create" operation
+     * @throws Exception
      */
-    @Test(expectedExceptions = { FHIROperationException.class } , expectedExceptionsMessageRegExp  = ".*Resource update, of type 'Patient', is not supported.*")
+    @Test
     public void testValidateOperationWithUpdateCreateDisabled() throws Exception {
-        FHIRPersistence persistence = Mockito.mock(FHIRPersistence.class);
-            Parameters input = Parameters.builder()
-                    .parameter(Parameter.builder()
-                        .name("resource")
-                        .resource(Patient.builder()
-                            .text(Narrative.builder()
-                                .div(Xhtml.of("<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"))
-                                .status(NarrativeStatus.GENERATED)
-                                .build())
+        Parameters input = Parameters.builder()
+                .parameter(Parameter.builder()
+                    .name("resource")
+                    .resource(Patient.builder()
+                        .id("1")
+                        .text(Narrative.builder()
+                            .div(Xhtml.of("<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"))
+                            .status(NarrativeStatus.GENERATED)
                             .build())
-                        .build(),
-                        Parameter.builder()
-                            .name("mode")
-                            .value(Code.of("update"))
-                            .build())
-                    .build();
-            FHIROperationContext operationContext =
-                    FHIROperationContext.createInstanceOperationContext("validate");
-            operationContext.setProperty(FHIROperationContext.PROPNAME_PERSISTENCE_IMPL, persistence);
-            
-            //mock the persistence layer implementation not to support the "update/create" operation
-            when(persistence.isUpdateCreateEnabled()).thenReturn(false);
-            
-            FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-            SingleResourceResult result = mock(SingleResourceResult.class);
+                        .build())
+                    .build(),
+                    Parameter.builder()
+                        .name("mode")
+                        .value(Code.of("update"))
+                        .build())
+                .build();
+        // mock the persistence layer implementation not to support the "update/create" operation
+        FHIROperationContext operationContext = opInstanceContextWithMockPersistence(false);
 
-         // mock and return a resource when resourceHelper.doRead() is invoked from validateOperation.doInvoke
-            when(result.isSuccess()).thenReturn(true);
-            when(result.getResource()).thenReturn(null);
-            when(resourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> result);
-            validateOperation.doInvoke(operationContext, Patient.class, "1", null, input, resourceHelper, null);
-        
+        FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
+        SingleResourceResult<?> result = mock(SingleResourceResult.class);
+
+        Issue expectedOutput = Issue.builder()
+                .severity(IssueSeverity.ERROR)
+                .code(IssueType.NOT_SUPPORTED)
+                .details(CodeableConcept.builder()
+                    .text("Resource update, of type 'Patient', is not supported.")
+                    .build())
+                .build();
+
+        // mock and return a resource when resourceHelper.doRead() is invoked from validateOperation.doInvoke
+        when(result.isSuccess()).thenReturn(true);
+        when(result.getResource()).thenReturn(null);
+        when(resourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> result);
+        Parameters output = validateOperation.doInvoke(operationContext, Patient.class, "1", null, input, resourceHelper, null);
+
+        OperationOutcome operationOutcome = output.getParameter().get(0).getResource().as(OperationOutcome.class);
+        assertEquals(operationOutcome.getIssue().size(), 1);
+        assertEquals(operationOutcome.getIssue().get(0), expectedOutput);
     }
-    
+
     /**
-     * Test validate operation with create mode type code and when the resource parameter is null. 
-     * @throws Exception 
-     * 
+     * Test validate operation with create mode type code and when the resource parameter is null.
+     * @throws Exception
      */
     @Test(expectedExceptions = { FHIROperationException.class } , expectedExceptionsMessageRegExp  = ".*Input parameter 'resource' must be present unless the mode is 'delete' or 'profile'*")
     public void testValidateOperationWithNoResourceParameter() throws Exception {
-        FHIRPersistence persistence = Mockito.mock(FHIRPersistence.class);
-            Parameters input = Parameters.builder()
-                    .parameter(Parameter.builder()
-                        .name("mode")
-                        .value(Code.of("create"))
-                        .build())
-                    .build();
-            FHIROperationContext operationContext =
-                    FHIROperationContext.createInstanceOperationContext("validate");
-            operationContext.setProperty(FHIROperationContext.PROPNAME_PERSISTENCE_IMPL, persistence);
-            
-            FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-            SingleResourceResult result = mock(SingleResourceResult.class);
+        Parameters input = Parameters.builder()
+                .parameter(Parameter.builder()
+                    .name("mode")
+                    .value(Code.of("create"))
+                    .build())
+                .build();
+        FHIROperationContext operationContext = opInstanceContextWithMockPersistence(true);
 
-         // mock and return a resource when resourceHelper.doRead() is invoked from validateOperation.doInvoke
-            when(result.isSuccess()).thenReturn(true);
-            when(result.getResource()).thenReturn(null);
-            when(resourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> result);
-            
-            validateOperation.doInvoke(operationContext, Patient.class, "1", null, input, resourceHelper, null);
+        FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
+        SingleResourceResult<?> result = mock(SingleResourceResult.class);
+
+        // mock and return a resource when resourceHelper.doRead() is invoked from validateOperation.doInvoke
+        when(result.isSuccess()).thenReturn(true);
+        when(result.getResource()).thenReturn(null);
+        when(resourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> result);
+
+        validateOperation.doInvoke(operationContext, Patient.class, "1", null, input, resourceHelper, null);
     }
-    
+
     /**
-     * Test validate operation with resource type level and update mode type code. 
-     * @throws Exception 
-     * 
+     * Test validate operation with resource type level and update mode type code.
+     * @throws Exception
      */
     @Test(expectedExceptions = { FHIROperationException.class } , expectedExceptionsMessageRegExp  = ".*Modes update and delete can only be used when the operation is invoked at the resource instance level.*")
     public void testValidateOperationWithTypeLevel() throws Exception {
@@ -638,24 +739,24 @@ public class ValidateOperationTest {
                         .value(Code.of("update"))
                         .build())
                 .build();
-            FHIROperationContext operationContext =
-                    FHIROperationContext.createResourceTypeOperationContext("validate");
-                       
-            FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-            validateOperation.doInvoke(operationContext, Patient.class, "1", null, input, resourceHelper, null);
+        FHIROperationContext operationContext =
+                FHIROperationContext.createResourceTypeOperationContext("validate");
+
+        FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
+        validateOperation.doInvoke(operationContext, Patient.class, "1", null, input, resourceHelper, null);
     }
-    
+
     /**
      * Test validate operation for valid interaction when mode = update and no resource already exists in DB.
      * @throws Exception
-     *
      */
-    @Test(expectedExceptions = { FHIROperationException.class } , expectedExceptionsMessageRegExp  = ".*The requested interaction of type 'update' is not allowed for resource type 'Patient'*")
+    @Test
     public void testValidateOperationDisAllowedInteractionForUpdateMode() throws Exception {
         Parameters input = Parameters.builder()
                 .parameter(Parameter.builder()
                     .name("resource")
                     .resource(Patient.builder()
+                        .id("1")
                         .text(Narrative.builder()
                             .div(Xhtml.of("<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"))
                             .status(NarrativeStatus.GENERATED)
@@ -667,41 +768,45 @@ public class ValidateOperationTest {
                         .value(Code.of("update"))
                         .build())
                 .build();
-            FHIROperationContext operationContext =
-                    FHIROperationContext.createResourceTypeOperationContext("validate");
-            FHIRResourceHelpers fhirResourceHelper = mock(FHIRResourceHelpers.class);
-            SingleResourceResult result = mock(SingleResourceResult.class);
+        FHIROperationContext operationContext = opInstanceContextWithMockPersistence(true);
 
-         // mock and return a resource when resourceHelper.doRead() is invoked from validateOperation.doInvoke
-            when(result.isSuccess()).thenReturn(true);
-            when(result.getResource()).thenReturn(null);
-            when(fhirResourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> result);
-            Issue interactionOutcome =
-                    OperationOutcome.Issue.builder()
-                    .severity(IssueSeverity.ERROR)
-                    .code(IssueType.BUSINESS_RULE)
-                    .details(CodeableConcept.builder()
-                        .text(string("The requested interaction of type 'update' is not allowed for resource type 'Patient'"))
-                        .build())
-                    .build();
-            FHIROperationException ex =
-                    new FHIROperationException("The requested interaction of type 'update' is not allowed for resource type 'Patient'")
-                    .withIssue(interactionOutcome);
-            doThrow(ex).when(fhirResourceHelper).validateInteraction(any(), anyString());
-            validateOperation.doInvoke(operationContext, Patient.class, "1", null, input, fhirResourceHelper, null);
+        FHIRResourceHelpers fhirResourceHelper = mock(FHIRResourceHelpers.class);
+        SingleResourceResult<?> result = mock(SingleResourceResult.class);
+
+        // mock and return a resource when resourceHelper.doRead() is invoked from validateOperation.doInvoke
+        when(result.isSuccess()).thenReturn(true);
+        when(result.getResource()).thenReturn(null);
+        when(fhirResourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> result);
+        Issue expectedInteractionOutcome =
+                OperationOutcome.Issue.builder()
+                .severity(IssueSeverity.ERROR)
+                .code(IssueType.BUSINESS_RULE)
+                .details(CodeableConcept.builder()
+                    .text("The requested interaction of type 'update' is not allowed for resource type 'Patient'")
+                    .build())
+                .build();
+        FHIROperationException ex =
+                new FHIROperationException("The requested interaction of type 'update' is not allowed for resource type 'Patient'")
+                .withIssue(expectedInteractionOutcome);
+        doThrow(ex).when(fhirResourceHelper).validateInteraction(any(), anyString());
+        Parameters output = validateOperation.doInvoke(operationContext, Patient.class, "1", null, input, fhirResourceHelper, null);
+
+        OperationOutcome operationOutcome = output.getParameter().get(0).getResource().as(OperationOutcome.class);
+        assertEquals(operationOutcome.getIssue().size(), 1);
+        assertEquals(operationOutcome.getIssue().get(0), expectedInteractionOutcome);
     }
-    
+
     /**
      * Test validate operation for valid interaction when mode = create.
      * @throws Exception
-     *
      */
-    @Test(expectedExceptions = { FHIROperationException.class } , expectedExceptionsMessageRegExp  = ".*The requested interaction of type 'update' is not allowed for resource type 'Patient'*")
+    @Test
     public void testValidateOperationDisAllowedInteractionForCreateMode() throws Exception {
         Parameters input = Parameters.builder()
                 .parameter(Parameter.builder()
                     .name("resource")
                     .resource(Patient.builder()
+                        .id("1")
                         .text(Narrative.builder()
                             .div(Xhtml.of("<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"))
                             .status(NarrativeStatus.GENERATED)
@@ -713,25 +818,46 @@ public class ValidateOperationTest {
                         .value(Code.of("create"))
                         .build())
                 .build();
-            FHIROperationContext operationContext =
-                    FHIROperationContext.createResourceTypeOperationContext("validate");
+        FHIROperationContext operationContext = opInstanceContextWithMockPersistence(true);
 
-            FHIRResourceHelpers fhirResourceHelper = mock(FHIRResourceHelpers.class);
-            Issue interactionOutcome =
-                    OperationOutcome.Issue.builder()
-                    .severity(IssueSeverity.ERROR)
-                    .code(IssueType.BUSINESS_RULE)
-                    .details(CodeableConcept.builder()
-                        .text(string("The requested interaction of type 'update' is not allowed for resource type 'Patient'"))
-                        .build())
-                    .build();
-            FHIROperationException ex =
-                    new FHIROperationException("The requested interaction of type 'update' is not allowed for resource type 'Patient'")
-                    .withIssue(interactionOutcome);
-             
-            doThrow(ex).when(fhirResourceHelper).validateInteraction(any(), anyString());
-             
-            validateOperation.doInvoke(operationContext, Patient.class, "1", null, input, fhirResourceHelper, null);
+        FHIRResourceHelpers fhirResourceHelper = mock(FHIRResourceHelpers.class);
+        Issue expectedInteractionOutcome =
+                OperationOutcome.Issue.builder()
+                .severity(IssueSeverity.ERROR)
+                .code(IssueType.BUSINESS_RULE)
+                .details(CodeableConcept.builder()
+                    .text("The requested interaction of type 'create' is not allowed for resource type 'Patient'")
+                    .build())
+                .build();
+
+        FHIROperationException ex =
+                new FHIROperationException("The requested interaction of type 'update' is not allowed for resource type 'Patient'")
+                .withIssue(expectedInteractionOutcome);
+        doThrow(ex).when(fhirResourceHelper).validateInteraction(any(), anyString());
+        when(fhirResourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> mock(SingleResourceResult.class));
+
+        Parameters output = validateOperation.doInvoke(operationContext, Patient.class, "1", null, input, fhirResourceHelper, null);
+
+        OperationOutcome operationOutcome = output.getParameter().get(0).getResource().as(OperationOutcome.class);
+        assertEquals(operationOutcome.getIssue().size(), 1);
+        assertEquals(operationOutcome.getIssue().get(0), expectedInteractionOutcome);
     }
 
+    private FHIROperationContext opInstanceContextWithMockPersistence(boolean isUpdateCreateEnbaled) {
+        return opInstanceContextWithMockPersistence(isUpdateCreateEnbaled, true);
+    }
+
+    private FHIROperationContext opInstanceContextWithMockPersistence(boolean isUpdateCreateEnbaled, boolean isDeleteSupported) {
+        FHIROperationContext operationContext =
+                FHIROperationContext.createInstanceOperationContext("validate");
+        FHIRPersistence persistence = mock(FHIRPersistence.class);
+
+        when(persistence.isUpdateCreateEnabled()).thenReturn(isUpdateCreateEnbaled);
+
+        when(persistence.isDeleteSupported()).thenReturn(isDeleteSupported);
+
+        operationContext.setProperty(FHIROperationContext.PROPNAME_PERSISTENCE_IMPL, persistence);
+
+        return operationContext;
+    }
 }


### PR DESCRIPTION
I also did some major refactoring so that we can return 200 OK for more cases.

Specifically, I tried to split the types of validation into two:
* If preconditions of the $validate operation are not met, we continue
to throw and thus return HTTP 400 Bad Request responses.
* If preconditions pass, but the interaction being validated (via
'mode') is not supported for the passed input, we now return HTTP 200 OK
with an OperationOutcome that contains one or more issues with severity
ERROR.

Example of the first type:
* mode 'update' is not allowed when invoking $validate at the resource type level
* 'resource' parameter is required when invoking $validate with mode=create

Example of the second type:
* the 'update' would not be valid at the passed URL because the passed resource does not have an id element
* the 'update' would not be valid at the passed URL because update/create is not enabled and there is no resource with that id yet

Signed-off-by: Lee Surprenant <lmsurpre@merative.com>