### PR TITLE
update the rebuild workflow

### DIFF
--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         java: [ '11' ]
-        tag: [ '5.0.0-RC1' ]
+        tag: [ '5.0.0-RC2' ]
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         java: [ '11' ]
-        tag: [ '4.11.0', '4.11.1' ]
+        tag: [ '4.11.1' ]
       fail-fast: false
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
1. No need to rebuild 5.0.0-RC1 any more now that 5.0.0-RC2 is out
2. No need to rebuild ibmcom/ibm-fhir-server 4.11.0 ... just do the latest (4.11.1).


Signed-off-by: Lee Surprenant <lmsurpre@merative.com>