### PR TITLE
issue #3650 - specify target version for more 1.0.0 artifacts

### DIFF
--- a/conformance/fhir-ig-davinci-pdex-plan-net/CHANGELOG.md
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/CHANGELOG.md
@@ -8,6 +8,8 @@ Corresponding to https://github.com/HL7/davinci-pdex-plan-net/commit/2c561128f86
 - Stripped narrative text to reduce the size and formatted the JSON contents (both via the ResourceProcessor tool)
 - Added version id to each targetProfile canonical reference (e.g. `http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization` -> `http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.0.0`)
 - Added version id to each valueSet binding target (e.g. `http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/InsuranceProductTypeVS` -> `http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/InsuranceProductTypeVS|1.0.0`)
+- Added version id to each extension's profile reference in each StructureDefinition
+- Added version element to each CodeSystem reference from each ValueSet definition
 
 Note: the examples were subsequently retrieved from http://hl7.org/fhir/us/davinci-pdex-plan-net/STU1/package.tgz on May 19, 2022.
 - Added version id to the Meta.profile entry for each example

--- a/conformance/fhir-ig-davinci-pdex-plan-net/CHANGELOG.md
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/CHANGELOG.md
@@ -19,6 +19,11 @@ Source - http://hl7.org/fhir/us/davinci-pdex-plan-net/STU1.1/package.tgz retriev
 - Modified CapabilityStatement-plan-net.json to remove <br/> tags between list items in the narrative text (which is invalid XHTML)
 - Modified ig-r4.json to remove parameters that aren't valid in FHIR R4
 - Stripped narrative text to reduce the size and formatted the JSON contents (both via the ResourceProcessor tool)
+- Added version id to each targetProfile canonical reference
+- Added version id to each valueSet binding target
+- Added version id to each extension's profile reference in each StructureDefinition
+- Added version element to each CodeSystem reference from each ValueSet definition
+
 
 # Steps to update
 1. download the npm package for whatever version of PDEX PlanNet you want (and note what downloads we used from where in this file)

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/StructureDefinition-plannet-Endpoint.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/StructureDefinition-plannet-Endpoint.json
@@ -733,7 +733,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/endpoint-usecase"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/endpoint-usecase|1.0.0"
                         ]
                     }
                 ],

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/StructureDefinition-plannet-HealthcareService.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/StructureDefinition-plannet-HealthcareService.json
@@ -733,7 +733,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/newpatients"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/newpatients|1.0.0"
                         ]
                     }
                 ],
@@ -785,7 +785,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/delivery-method"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/delivery-method|1.0.0"
                         ]
                     }
                 ],

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/StructureDefinition-plannet-Location.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/StructureDefinition-plannet-Location.json
@@ -733,7 +733,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/newpatients"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/newpatients|1.0.0"
                         ]
                     }
                 ],
@@ -785,7 +785,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/accessibility"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/accessibility|1.0.0"
                         ]
                     }
                 ],
@@ -841,7 +841,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/StructureDefinition/location-boundary-geojson"
+                            "http://hl7.org/fhir/StructureDefinition/location-boundary-geojson|1.0.0"
                         ]
                     }
                 ],

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/StructureDefinition-plannet-Location.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/StructureDefinition-plannet-Location.json
@@ -841,7 +841,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/StructureDefinition/location-boundary-geojson|1.0.0"
+                            "http://hl7.org/fhir/StructureDefinition/location-boundary-geojson"
                         ]
                     }
                 ],

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/StructureDefinition-plannet-Network.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/StructureDefinition-plannet-Network.json
@@ -750,7 +750,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/location-reference"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/location-reference|1.0.0"
                         ]
                     }
                 ],

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/StructureDefinition-plannet-Organization.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/StructureDefinition-plannet-Organization.json
@@ -750,7 +750,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/qualification"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/qualification|1.0.0"
                         ]
                     }
                 ],
@@ -805,7 +805,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/org-description"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/org-description|1.0.0"
                         ]
                     }
                 ],

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/StructureDefinition-plannet-OrganizationAffiliation.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/StructureDefinition-plannet-OrganizationAffiliation.json
@@ -740,7 +740,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/qualification"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/qualification|1.0.0"
                         ]
                     }
                 ],

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/StructureDefinition-plannet-PractitionerRole.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/StructureDefinition-plannet-PractitionerRole.json
@@ -758,7 +758,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/newpatients"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/newpatients|1.0.0"
                         ]
                     }
                 ],
@@ -810,7 +810,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/network-reference"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/network-reference|1.0.0"
                         ]
                     }
                 ],
@@ -865,7 +865,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/qualification"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/qualification|1.0.0"
                         ]
                     }
                 ],

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-AcceptingPatientsVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-AcceptingPatientsVS.json
@@ -41,7 +41,8 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/AcceptingPatientsCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/AcceptingPatientsCS",
+                "version": "1.0.0"
             }
         ]
     }

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-AccessibilityVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-AccessibilityVS.json
@@ -41,7 +41,8 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/AccessibilityCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/AccessibilityCS",
+                "version": "1.0.0"
             }
         ]
     }

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-DeliveryMethodVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-DeliveryMethodVS.json
@@ -41,7 +41,8 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/DeliveryMethodCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/DeliveryMethodCS",
+                "version": "1.0.0"
             }
         ]
     }

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-EndpointConnectionTypeVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-EndpointConnectionTypeVS.json
@@ -44,7 +44,8 @@
                 "system": "http://terminology.hl7.org/CodeSystem/endpoint-connection-type"
             },
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/EndpointConnectionTypeCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/EndpointConnectionTypeCS",
+                "version": "1.0.0"
             }
         ]
     }

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-EndpointPayloadTypeVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-EndpointPayloadTypeVS.json
@@ -42,6 +42,7 @@
         "include": [
             {
                 "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/EndpointPayloadTypeCS",
+                "version": "1.0.0",
                 "concept": [
                     {
                         "code": "NA",

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-HealthcareServiceCategoryVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-HealthcareServiceCategoryVS.json
@@ -41,7 +41,8 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/HealthcareServiceCategoryCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/HealthcareServiceCategoryCS",
+                "version": "1.0.0"
             }
         ]
     }

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-InsurancePlanTypeVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-InsurancePlanTypeVS.json
@@ -41,7 +41,8 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/InsurancePlanTypeCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/InsurancePlanTypeCS",
+                "version": "1.0.0"
             }
         ]
     }

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-InsuranceProductTypeVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-InsuranceProductTypeVS.json
@@ -41,7 +41,8 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/InsuranceProductTypeCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/InsuranceProductTypeCS",
+                "version": "1.0.0"
             }
         ]
     }

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-LanguageProficiencyVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-LanguageProficiencyVS.json
@@ -41,7 +41,8 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/LanguageProficiencyCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/LanguageProficiencyCS",
+                "version": "1.0.0"
             }
         ]
     }

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-MinEndpointConnectionTypeVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-MinEndpointConnectionTypeVS.json
@@ -59,6 +59,7 @@
             },
             {
                 "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/EndpointConnectionTypeCS",
+                "version": "1.0.0",
                 "concept": [
                     {
                         "code": "hl7-fhir-opn",

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-NetworkTypeVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-NetworkTypeVS.json
@@ -42,6 +42,7 @@
         "include": [
             {
                 "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/OrgTypeCS",
+                "version": "1.0.0",
                 "concept": [
                     {
                         "code": "ntwk"

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-OrgTypeVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-OrgTypeVS.json
@@ -41,12 +41,14 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/OrgTypeCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/OrgTypeCS",
+                "version": "1.0.0"
             }
         ],
         "exclude": [
             {
                 "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/OrgTypeCS",
+                "version": "1.0.0",
                 "concept": [
                     {
                         "code": "ntwk"

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-OrganizationAffiliationRoleVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-OrganizationAffiliationRoleVS.json
@@ -44,7 +44,8 @@
                 "system": "http://hl7.org/fhir/organization-role"
             },
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/OrganizationAffiliationRoleCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/OrganizationAffiliationRoleCS",
+                "version": "1.0.0"
             }
         ],
         "exclude": [

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-PractitionerRoleVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-PractitionerRoleVS.json
@@ -41,7 +41,8 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/ProviderRoleCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/ProviderRoleCS",
+                "version": "1.0.0"
             },
             {
                 "system": "http://terminology.hl7.org/CodeSystem/practitioner-role"

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-QualificationStatusVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-QualificationStatusVS.json
@@ -41,7 +41,8 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/QualificationStatusCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/QualificationStatusCS",
+                "version": "1.0.0"
             }
         ]
     }

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-VirtualModalitiesVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/100/package/ValueSet-VirtualModalitiesVS.json
@@ -41,7 +41,8 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/VirtualModalitiesCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/VirtualModalitiesCS",
+                "version": "1.0.0"
             }
         ]
     }

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-accessibility.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-accessibility.json
@@ -245,7 +245,7 @@
                 "isSummary": false,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/AccessibilityVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/AccessibilityVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -285,7 +285,7 @@
                 ],
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/AccessibilityVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/AccessibilityVS|1.1.0"
                 }
             }
         ]

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-communication-proficiency.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-communication-proficiency.json
@@ -292,7 +292,7 @@
                 "isSummary": false,
                 "binding": {
                     "strength": "required",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/LanguageProficiencyVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/LanguageProficiencyVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -348,7 +348,7 @@
                 "max": "1",
                 "binding": {
                     "strength": "required",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/LanguageProficiencyVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/LanguageProficiencyVS|1.1.0"
                 }
             }
         ]

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-delivery-method.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-delivery-method.json
@@ -367,7 +367,7 @@
                 "isSummary": false,
                 "binding": {
                     "strength": "required",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/DeliveryMethodVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/DeliveryMethodVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -567,7 +567,7 @@
                 "isSummary": false,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/VirtualModalitiesVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/VirtualModalitiesVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -840,7 +840,7 @@
                 ],
                 "binding": {
                     "strength": "required",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/DeliveryMethodVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/DeliveryMethodVS|1.1.0"
                 }
             },
             {
@@ -873,7 +873,7 @@
                 ],
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/VirtualModalitiesVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/VirtualModalitiesVS|1.1.0"
                 }
             },
             {

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-endpoint-usecase.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-endpoint-usecase.json
@@ -368,7 +368,7 @@
                 "isSummary": false,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/EndpointUsecaseVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/EndpointUsecaseVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -838,7 +838,7 @@
                 ],
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/EndpointUsecaseVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/EndpointUsecaseVS|1.1.0"
                 }
             },
             {

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-location-reference.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-location-reference.json
@@ -230,7 +230,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0"
                         ]
                     }
                 ],
@@ -282,7 +282,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0"
                         ]
                     }
                 ],

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-network-reference.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-network-reference.json
@@ -230,7 +230,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Network"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Network|1.1.0"
                         ]
                     }
                 ],
@@ -282,7 +282,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Network"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Network|1.1.0"
                         ]
                     }
                 ],

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-newpatients.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-newpatients.json
@@ -375,7 +375,7 @@
                 "isSummary": false,
                 "binding": {
                     "strength": "required",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/AcceptingPatientsVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/AcceptingPatientsVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -560,7 +560,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Network"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Network|1.1.0"
                         ]
                     }
                 ],
@@ -1053,7 +1053,7 @@
                 ],
                 "binding": {
                     "strength": "required",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/AcceptingPatientsVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/AcceptingPatientsVS|1.1.0"
                 }
             },
             {
@@ -1083,7 +1083,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Network"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Network|1.1.0"
                         ]
                     }
                 ]

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-plannet-Endpoint.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-plannet-Endpoint.json
@@ -733,7 +733,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/endpoint-usecase"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/endpoint-usecase|1.1.0"
                         ]
                     }
                 ],
@@ -942,11 +942,11 @@
                     "extension": [
                         {
                             "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet",
-                            "valueCanonical": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/MinEndpointConnectionTypeVS"
+                            "valueCanonical": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/MinEndpointConnectionTypeVS|1.1.0"
                         }
                     ],
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/EndpointConnectionTypeVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/EndpointConnectionTypeVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -1017,7 +1017,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],
@@ -1494,7 +1494,7 @@
                 "isSummary": true,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/EndpointPayloadTypeVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/EndpointPayloadTypeVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -1683,11 +1683,11 @@
                     "extension": [
                         {
                             "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet",
-                            "valueCanonical": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/MinEndpointConnectionTypeVS"
+                            "valueCanonical": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/MinEndpointConnectionTypeVS|1.1.0"
                         }
                     ],
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/EndpointConnectionTypeVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/EndpointConnectionTypeVS|1.1.0"
                 }
             },
             {
@@ -1702,7 +1702,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],
@@ -1730,7 +1730,7 @@
                 "mustSupport": true,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/EndpointPayloadTypeVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/EndpointPayloadTypeVS|1.1.0"
                 }
             },
             {

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-plannet-HealthcareService.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-plannet-HealthcareService.json
@@ -733,7 +733,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/newpatients"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/newpatients|1.1.0"
                         ]
                     }
                 ],
@@ -785,7 +785,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/delivery-method"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/delivery-method|1.1.0"
                         ]
                     }
                 ],
@@ -1368,7 +1368,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],
@@ -1428,7 +1428,7 @@
                 "isSummary": true,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/HealthcareServiceCategoryVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/HealthcareServiceCategoryVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -1476,7 +1476,7 @@
                 "isSummary": true,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/HealthcareServiceTypeVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/HealthcareServiceTypeVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -1517,7 +1517,7 @@
                 "isSummary": true,
                 "binding": {
                     "strength": "required",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/SpecialtiesVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/SpecialtiesVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -1542,7 +1542,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0"
                         ]
                     }
                 ],
@@ -2201,7 +2201,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0"
                         ]
                     }
                 ],
@@ -3386,7 +3386,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint|1.1.0"
                         ]
                     }
                 ],
@@ -3495,7 +3495,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],
@@ -3509,7 +3509,7 @@
                 "mustSupport": true,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/HealthcareServiceCategoryVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/HealthcareServiceCategoryVS|1.1.0"
                 }
             },
             {
@@ -3518,7 +3518,7 @@
                 "mustSupport": true,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/HealthcareServiceTypeVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/HealthcareServiceTypeVS|1.1.0"
                 }
             },
             {
@@ -3527,7 +3527,7 @@
                 "mustSupport": true,
                 "binding": {
                     "strength": "required",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/SpecialtiesVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/SpecialtiesVS|1.1.0"
                 }
             },
             {
@@ -3537,7 +3537,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0"
                         ]
                     }
                 ],
@@ -3608,7 +3608,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0"
                         ]
                     }
                 ],
@@ -3671,7 +3671,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint|1.1.0"
                         ]
                     }
                 ],

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-plannet-InsurancePlan.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-plannet-InsurancePlan.json
@@ -1324,7 +1324,7 @@
                 "isSummary": true,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/InsuranceProductTypeVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/InsuranceProductTypeVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -1467,7 +1467,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],
@@ -1501,7 +1501,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],
@@ -1535,7 +1535,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0"
                         ]
                     }
                 ],
@@ -2673,7 +2673,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint|1.1.0"
                         ]
                     }
                 ],
@@ -2714,7 +2714,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Network"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Network|1.1.0"
                         ]
                     }
                 ],
@@ -3660,7 +3660,7 @@
                 "isSummary": false,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/InsurancePlanTypeVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/InsurancePlanTypeVS|1.1.0"
                 }
             },
             {
@@ -3679,7 +3679,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0"
                         ]
                     }
                 ],
@@ -3714,7 +3714,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Network"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Network|1.1.0"
                         ]
                     }
                 ],
@@ -4772,7 +4772,7 @@
                 "mustSupport": true,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/InsuranceProductTypeVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/InsuranceProductTypeVS|1.1.0"
                 }
             },
             {
@@ -4798,7 +4798,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],
@@ -4812,7 +4812,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],
@@ -4825,7 +4825,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0"
                         ]
                     }
                 ],
@@ -4868,7 +4868,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint|1.1.0"
                         ]
                     }
                 ],
@@ -4881,7 +4881,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Network"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Network|1.1.0"
                         ]
                     }
                 ],
@@ -4899,7 +4899,7 @@
                 "mustSupport": true,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/InsurancePlanTypeVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/InsurancePlanTypeVS|1.1.0"
                 }
             },
             {
@@ -4909,7 +4909,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0"
                         ]
                     }
                 ],
@@ -4922,7 +4922,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Network"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Network|1.1.0"
                         ]
                     }
                 ]

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-plannet-Location.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-plannet-Location.json
@@ -733,7 +733,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/newpatients"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/newpatients|1.1.0"
                         ]
                     }
                 ],
@@ -785,7 +785,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/accessibility"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/accessibility|1.1.0"
                         ]
                     }
                 ],
@@ -831,7 +831,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/StructureDefinition/location-boundary-geojson"
+                            "http://hl7.org/fhir/StructureDefinition/location-boundary-geojson|1.1.0"
                         ]
                     }
                 ],
@@ -3202,7 +3202,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],
@@ -3249,7 +3249,7 @@
                         ],
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0"
                         ]
                     }
                 ],
@@ -3660,7 +3660,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint|1.1.0"
                         ]
                     }
                 ],
@@ -3853,7 +3853,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ]
@@ -3871,7 +3871,7 @@
                         ],
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0"
                         ]
                     }
                 ],
@@ -3914,7 +3914,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint|1.1.0"
                         ]
                     }
                 ],

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-plannet-Location.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-plannet-Location.json
@@ -831,7 +831,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/StructureDefinition/location-boundary-geojson|1.1.0"
+                            "http://hl7.org/fhir/StructureDefinition/location-boundary-geojson"
                         ]
                     }
                 ],

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-plannet-Network.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-plannet-Network.json
@@ -750,7 +750,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/location-reference"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/location-reference|1.1.0"
                         ]
                     }
                 ],
@@ -1509,7 +1509,7 @@
                 "isSummary": true,
                 "binding": {
                     "strength": "required",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/NetworkTypeVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/NetworkTypeVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -2425,7 +2425,7 @@
                         ],
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],
@@ -3249,7 +3249,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint|1.1.0"
                         ]
                     }
                 ],
@@ -3339,7 +3339,7 @@
                 "mustSupport": true,
                 "binding": {
                     "strength": "required",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/NetworkTypeVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/NetworkTypeVS|1.1.0"
                 }
             },
             {
@@ -3362,7 +3362,7 @@
                         ],
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],
@@ -3431,7 +3431,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint|1.1.0"
                         ]
                     }
                 ],

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-plannet-Organization.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-plannet-Organization.json
@@ -750,7 +750,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/qualification"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/qualification|1.1.0"
                         ]
                     }
                 ],
@@ -795,7 +795,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/org-description"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/org-description|1.1.0"
                         ]
                     }
                 ],
@@ -1554,7 +1554,7 @@
                 "isSummary": true,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/OrgTypeVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/OrgTypeVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -2946,7 +2946,7 @@
                         ],
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],
@@ -3876,7 +3876,7 @@
                 "mustSupport": true,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/OrgTypeVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/OrgTypeVS|1.1.0"
                 }
             },
             {
@@ -3971,7 +3971,7 @@
                         ],
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-plannet-OrganizationAffiliation.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-plannet-OrganizationAffiliation.json
@@ -740,7 +740,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/qualification"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/qualification|1.1.0"
                         ]
                     }
                 ],
@@ -1364,7 +1364,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],
@@ -1404,7 +1404,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],
@@ -1444,7 +1444,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Network"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Network|1.1.0"
                         ]
                     }
                 ],
@@ -1494,7 +1494,7 @@
                 "isSummary": true,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/OrganizationAffiliationRoleVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/OrganizationAffiliationRoleVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -1535,7 +1535,7 @@
                 "isSummary": true,
                 "binding": {
                     "strength": "required",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/SpecialtiesVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/SpecialtiesVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -1560,7 +1560,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0"
                         ]
                     }
                 ],
@@ -1604,7 +1604,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-HealthcareService"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-HealthcareService|1.1.0"
                         ]
                     }
                 ],
@@ -2026,7 +2026,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint|1.1.0"
                         ]
                     }
                 ],
@@ -2130,7 +2130,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],
@@ -2143,7 +2143,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],
@@ -2156,7 +2156,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Network"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Network|1.1.0"
                         ]
                     }
                 ],
@@ -2168,7 +2168,7 @@
                 "mustSupport": true,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/OrganizationAffiliationRoleVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/OrganizationAffiliationRoleVS|1.1.0"
                 }
             },
             {
@@ -2177,7 +2177,7 @@
                 "mustSupport": true,
                 "binding": {
                     "strength": "required",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/SpecialtiesVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/SpecialtiesVS|1.1.0"
                 }
             },
             {
@@ -2187,7 +2187,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0"
                         ]
                     }
                 ],
@@ -2200,7 +2200,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-HealthcareService"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-HealthcareService|1.1.0"
                         ]
                     }
                 ],
@@ -2233,7 +2233,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint|1.1.0"
                         ]
                     }
                 ],

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-plannet-Practitioner.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-plannet-Practitioner.json
@@ -3465,7 +3465,7 @@
                 "isSummary": false,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/IndividualSpecialtyAndDegreeLicenseCertificateVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/IndividualSpecialtyAndDegreeLicenseCertificateVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -4003,7 +4003,7 @@
                 "mustSupport": true,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/IndividualSpecialtyAndDegreeLicenseCertificateVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/IndividualSpecialtyAndDegreeLicenseCertificateVS|1.1.0"
                 }
             },
             {

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-plannet-PractitionerRole.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-plannet-PractitionerRole.json
@@ -758,7 +758,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/newpatients"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/newpatients|1.1.0"
                         ]
                     }
                 ],
@@ -810,7 +810,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/network-reference"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/network-reference|1.1.0"
                         ]
                     }
                 ],
@@ -855,7 +855,7 @@
                     {
                         "code": "Extension",
                         "profile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/qualification"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/qualification|1.1.0"
                         ]
                     }
                 ],
@@ -1353,7 +1353,7 @@
                 "isSummary": false,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/IndividualSpecialtyAndDegreeLicenseCertificateVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/IndividualSpecialtyAndDegreeLicenseCertificateVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -1538,7 +1538,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],
@@ -1800,7 +1800,7 @@
                 "isSummary": false,
                 "binding": {
                     "strength": "required",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/QualificationStatusVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/QualificationStatusVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -2184,7 +2184,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0"
                         ]
                     }
                 ],
@@ -3048,7 +3048,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Practitioner"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Practitioner|1.1.0"
                         ]
                     }
                 ],
@@ -3088,7 +3088,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],
@@ -3146,7 +3146,7 @@
                 "isSummary": true,
                 "binding": {
                     "strength": "required",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/PractitionerRoleVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/PractitionerRoleVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -3195,7 +3195,7 @@
                 "isSummary": true,
                 "binding": {
                     "strength": "required",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/IndividualAndGroupSpecialtiesVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/IndividualAndGroupSpecialtiesVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -3228,7 +3228,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0"
                         ]
                     }
                 ],
@@ -3276,7 +3276,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-HealthcareService"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-HealthcareService|1.1.0"
                         ]
                     }
                 ],
@@ -4407,7 +4407,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint|1.1.0"
                         ]
                     }
                 ],
@@ -4528,7 +4528,7 @@
                 "path": "PractitionerRole.extension.extension.value[x]",
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/IndividualSpecialtyAndDegreeLicenseCertificateVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/IndividualSpecialtyAndDegreeLicenseCertificateVS|1.1.0"
                 }
             },
             {
@@ -4560,7 +4560,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Practitioner"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Practitioner|1.1.0"
                         ]
                     }
                 ],
@@ -4573,7 +4573,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],
@@ -4585,7 +4585,7 @@
                 "mustSupport": true,
                 "binding": {
                     "strength": "required",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/PractitionerRoleVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/PractitionerRoleVS|1.1.0"
                 }
             },
             {
@@ -4594,7 +4594,7 @@
                 "mustSupport": true,
                 "binding": {
                     "strength": "required",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/IndividualAndGroupSpecialtiesVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/IndividualAndGroupSpecialtiesVS|1.1.0"
                 }
             },
             {
@@ -4604,7 +4604,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0"
                         ]
                     }
                 ],
@@ -4617,7 +4617,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-HealthcareService"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-HealthcareService|1.1.0"
                         ]
                     }
                 ],
@@ -4725,7 +4725,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint|1.1.0"
                         ]
                     }
                 ],

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-practitioner-qualification.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-practitioner-qualification.json
@@ -416,7 +416,7 @@
                 "isSummary": false,
                 "binding": {
                     "strength": "required",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/QualificationStatusVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/QualificationStatusVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -954,7 +954,7 @@
                 "fixedCode": "active",
                 "binding": {
                     "strength": "required",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/QualificationStatusVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/QualificationStatusVS|1.1.0"
                 }
             },
             {
@@ -997,7 +997,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0"
                         ]
                     }
                 ]

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-qualification.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-qualification.json
@@ -564,7 +564,7 @@
                 "isSummary": false,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/SpecialtyAndDegreeLicenseCertificateVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/SpecialtyAndDegreeLicenseCertificateVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -749,7 +749,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],
@@ -1011,7 +1011,7 @@
                 "isSummary": false,
                 "binding": {
                     "strength": "required",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/QualificationStatusVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/QualificationStatusVS|1.1.0"
                 },
                 "mapping": [
                     {
@@ -1395,7 +1395,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0"
                         ]
                     }
                 ],
@@ -1714,7 +1714,7 @@
                 ],
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/SpecialtyAndDegreeLicenseCertificateVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/SpecialtyAndDegreeLicenseCertificateVS|1.1.0"
                 }
             },
             {
@@ -1743,7 +1743,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ]
@@ -1794,7 +1794,7 @@
                 "fixedCode": "active",
                 "binding": {
                     "strength": "required",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/QualificationStatusVS"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/QualificationStatusVS|1.1.0"
                 }
             },
             {
@@ -1854,7 +1854,7 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0"
                         ]
                     }
                 ],

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-via-intermediary.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/StructureDefinition-via-intermediary.json
@@ -230,10 +230,10 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-PractitionerRole",
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-OrganizationAffiliation",
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location",
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-PractitionerRole|1.1.0",
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-OrganizationAffiliation|1.1.0",
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0",
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],
@@ -285,10 +285,10 @@
                     {
                         "code": "Reference",
                         "targetProfile": [
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-PractitionerRole",
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-OrganizationAffiliation",
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location",
-                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization"
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-PractitionerRole|1.1.0",
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-OrganizationAffiliation|1.1.0",
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Location|1.1.0",
+                            "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization|1.1.0"
                         ]
                     }
                 ],

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-AcceptingPatientsVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-AcceptingPatientsVS.json
@@ -41,7 +41,8 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/AcceptingPatientsCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/AcceptingPatientsCS",
+                "version": "1.1.0"
             }
         ]
     }

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-AccessibilityVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-AccessibilityVS.json
@@ -41,7 +41,8 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/AccessibilityCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/AccessibilityCS",
+                "version": "1.1.0"
             }
         ]
     }

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-DeliveryMethodVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-DeliveryMethodVS.json
@@ -41,7 +41,8 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/DeliveryMethodCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/DeliveryMethodCS",
+                "version": "1.1.0"
             }
         ]
     }

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-EndpointConnectionTypeVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-EndpointConnectionTypeVS.json
@@ -44,7 +44,8 @@
                 "system": "http://terminology.hl7.org/CodeSystem/endpoint-connection-type"
             },
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/EndpointConnectionTypeCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/EndpointConnectionTypeCS",
+                "version": "1.1.0"
             }
         ]
     }

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-EndpointPayloadTypeVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-EndpointPayloadTypeVS.json
@@ -42,6 +42,7 @@
         "include": [
             {
                 "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/EndpointPayloadTypeCS",
+                "version": "1.1.0",
                 "concept": [
                     {
                         "code": "NA",

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-HealthcareServiceCategoryVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-HealthcareServiceCategoryVS.json
@@ -41,7 +41,8 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/HealthcareServiceCategoryCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/HealthcareServiceCategoryCS",
+                "version": "1.1.0"
             }
         ]
     }

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-InsurancePlanTypeVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-InsurancePlanTypeVS.json
@@ -41,7 +41,8 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/InsurancePlanTypeCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/InsurancePlanTypeCS",
+                "version": "1.1.0"
             }
         ]
     }

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-InsuranceProductTypeVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-InsuranceProductTypeVS.json
@@ -41,7 +41,8 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/InsuranceProductTypeCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/InsuranceProductTypeCS",
+                "version": "1.1.0"
             }
         ]
     }

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-LanguageProficiencyVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-LanguageProficiencyVS.json
@@ -41,7 +41,8 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/LanguageProficiencyCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/LanguageProficiencyCS",
+                "version": "1.1.0"
             }
         ]
     }

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-MinEndpointConnectionTypeVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-MinEndpointConnectionTypeVS.json
@@ -59,6 +59,7 @@
             },
             {
                 "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/EndpointConnectionTypeCS",
+                "version": "1.1.0",
                 "concept": [
                     {
                         "code": "hl7-fhir-opn",

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-NetworkTypeVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-NetworkTypeVS.json
@@ -42,6 +42,7 @@
         "include": [
             {
                 "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/OrgTypeCS",
+                "version": "1.1.0",
                 "concept": [
                     {
                         "code": "ntwk"

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-OrgTypeVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-OrgTypeVS.json
@@ -41,12 +41,14 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/OrgTypeCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/OrgTypeCS",
+                "version": "1.1.0"
             }
         ],
         "exclude": [
             {
                 "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/OrgTypeCS",
+                "version": "1.1.0",
                 "concept": [
                     {
                         "code": "ntwk"

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-OrganizationAffiliationRoleVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-OrganizationAffiliationRoleVS.json
@@ -44,7 +44,8 @@
                 "system": "http://hl7.org/fhir/organization-role"
             },
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/OrganizationAffiliationRoleCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/OrganizationAffiliationRoleCS",
+                "version": "1.1.0"
             }
         ],
         "exclude": [

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-PractitionerRoleVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-PractitionerRoleVS.json
@@ -41,7 +41,8 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/ProviderRoleCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/ProviderRoleCS",
+                "version": "1.1.0"
             },
             {
                 "system": "http://terminology.hl7.org/CodeSystem/practitioner-role"

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-QualificationStatusVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-QualificationStatusVS.json
@@ -41,7 +41,8 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/QualificationStatusCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/QualificationStatusCS",
+                "version": "1.1.0"
             }
         ]
     }

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-VirtualModalitiesVS.json
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/resources/hl7/fhir/us/davinci-pdex-plan-net/110/package/ValueSet-VirtualModalitiesVS.json
@@ -41,7 +41,8 @@
     "compose": {
         "include": [
             {
-                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/VirtualModalitiesCS"
+                "system": "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/VirtualModalitiesCS",
+                "version": "1.1.0"
             }
         ]
     }

--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/test/java/org/linuxforhealth/fhir/ig/davinci/plannet/test/ConstraintGeneratorTest.java
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/test/java/org/linuxforhealth/fhir/ig/davinci/plannet/test/ConstraintGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,8 +7,6 @@
 package org.linuxforhealth.fhir.ig.davinci.plannet.test;
 
 import static org.linuxforhealth.fhir.path.util.FHIRPathUtil.compile;
-
-import org.testng.annotations.Test;
 
 import org.linuxforhealth.fhir.ig.davinci.pdex.plannet.PlanNet100ResourceProvider;
 import org.linuxforhealth.fhir.ig.davinci.pdex.plannet.PlanNet110ResourceProvider;
@@ -19,18 +17,26 @@ import org.linuxforhealth.fhir.model.util.ModelSupport;
 import org.linuxforhealth.fhir.profile.ProfileSupport;
 import org.linuxforhealth.fhir.registry.resource.FHIRRegistryResource;
 import org.linuxforhealth.fhir.registry.spi.FHIRRegistryResourceProvider;
+import org.testng.annotations.Test;
 
 public class ConstraintGeneratorTest {
+    private static boolean DEBUG = true;
+
     @Test
     public static void test100ConstraintGenerator() throws Exception {
         FHIRRegistryResourceProvider provider = new PlanNet100ResourceProvider();
         for (FHIRRegistryResource registryResource : provider.getRegistryResources()) {
             if (StructureDefinition.class.equals(registryResource.getResourceType())) {
                 String url = registryResource.getUrl();
-                System.out.println(url);
+                String version = registryResource.getVersion().toString();
+                if (DEBUG) {
+                    System.out.println(url);
+                }
                 Class<?> type = ModelSupport.isResourceType(registryResource.getType()) ? ModelSupport.getResourceType(registryResource.getType()) : Extension.class;
-                for (Constraint constraint : ProfileSupport.getConstraints(url, type)) {
-                    System.out.println("    " + constraint);
+                for (Constraint constraint : ProfileSupport.getConstraints(url + "|" + version, type)) {
+                    if (DEBUG) {
+                        System.out.println("    " + constraint);
+                    }
                     if (!Constraint.LOCATION_BASE.equals(constraint.location())) {
                         compile(constraint.location());
                     }
@@ -46,10 +52,15 @@ public class ConstraintGeneratorTest {
         for (FHIRRegistryResource registryResource : provider.getRegistryResources()) {
             if (StructureDefinition.class.equals(registryResource.getResourceType())) {
                 String url = registryResource.getUrl();
-                System.out.println(url);
+                String version = registryResource.getVersion().toString();
+                if (DEBUG) {
+                    System.out.println(url);
+                }
                 Class<?> type = ModelSupport.isResourceType(registryResource.getType()) ? ModelSupport.getResourceType(registryResource.getType()) : Extension.class;
-                for (Constraint constraint : ProfileSupport.getConstraints(url, type)) {
-                    System.out.println("    " + constraint);
+                for (Constraint constraint : ProfileSupport.getConstraints(url + "|" + version, type)) {
+                    if (DEBUG) {
+                        System.out.println("    " + constraint);
+                    }
                     if (!Constraint.LOCATION_BASE.equals(constraint.location())) {
                         compile(constraint.location());
                     }

--- a/fhir-profile/src/main/java/org/linuxforhealth/fhir/profile/ProfileSupport.java
+++ b/fhir-profile/src/main/java/org/linuxforhealth/fhir/profile/ProfileSupport.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019, 2021
+ * (C) Copyright IBM Corp. 2019, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -227,6 +227,11 @@ public final class ProfileSupport {
         return constraints;
     }
 
+    /**
+     * Get constraints for all the resource-asserted profiles of the passed resource.
+     * @param resource
+     * @return
+     */
     public static List<Constraint> getConstraints(Resource resource) {
         return getConstraints(getResourceAssertedProfiles(resource), resource.getClass());
     }
@@ -270,6 +275,12 @@ public final class ProfileSupport {
         return false;
     }
 
+    /**
+     * @param url the canonical url (with optional version postfix and optional fragment id for contained resources)
+     *       for a profile in the registry
+     * @param type the target resource or element type for the profile
+     * @return
+     */
     public static List<Constraint> getConstraints(String url, Class<?> type) {
         StructureDefinition profile = getProfile(url, type);
         if (profile != null) {
@@ -286,7 +297,7 @@ public final class ProfileSupport {
         } else {
             key = key(url);
         }
-        
+
         Map<CacheKey, List<Constraint>> constraintCache = CacheManager.getCacheAsMap(CONSTRAINT_CACHE_NAME, CONSTRAINT_CACHE_CONFIG);
 
         try {
@@ -350,6 +361,12 @@ public final class ProfileSupport {
         return isProfile(structureDefinition) ? structureDefinition : null;
     }
 
+    /**
+     * @param url the canonical url (with optional version postfix and optional fragment id for contained resources)
+     *       for a profile in the registry
+     * @param type the resource or element type
+     * @return
+     */
     public static StructureDefinition getProfile(String url, Class<?> type) {
         StructureDefinition profile = getProfile(url);
         return (profile != null && isApplicable(profile, type)) ? profile : null;
@@ -359,6 +376,12 @@ public final class ProfileSupport {
         return getStructureDefinition(HL7_STRUCTURE_DEFINITION_URL_PREFIX + ModelSupport.getTypeName(modelClass));
     }
 
+    /**
+     * @param url the canonical url (with optional version postfix and optional fragment id for contained resources)
+     *     for a profile in the registry
+     * @return the StructureDefinition for the given canonical url if it exists, null otherwise
+     * @throws ClassCastException if the resource exists in the registry but is not a StructureDefinition
+     */
     public static StructureDefinition getStructureDefinition(String url) {
         return FHIRRegistry.getInstance().getResource(url, StructureDefinition.class);
     }
@@ -369,6 +392,12 @@ public final class ProfileSupport {
         return HL7_STRUCTURE_DEFINITION_URL_PREFIX + typeName;
     }
 
+    /**
+     * Is the StructureDefinition applicable to the resource or element type?
+     * @param profile
+     * @param type the resource or element type to check
+     * @return
+     */
     public static boolean isApplicable(StructureDefinition profile, Class<?> type) {
         if (profile == null || type == null) {
             return false;


### PR DESCRIPTION
1. update StructureDefinition artifacts to specify that the plannet
extensions referenced from 1.0.0 profiles should be the 1.0.0 version of
the extension definitions

2. update ValueSet artifacts to specify that plannet code
systems referenced from 1.0.0 valuesets should be the 1.0.0 version of
those code systems

3. fix the ConstraintGeneratorTest to specify the version of artifacts
to generate constraints from (previously it would always use the
"latest" vesion, even for the test that was supposed to execute against
the 1.0.0 artifacts)

I also added javadoc to some methods in ProfileSupport.java

And now I preemptively added similar version references for the 1.1.0 version of these artifacts as well.

Signed-off-by: Lee Surprenant <lmsurpre@merative.com>