### PR TITLE
issue #3959 - avoid needless whitespace handling in String.split

### DIFF
--- a/fhir-search/src/main/java/org/linuxforhealth/fhir/search/util/SearchHelper.java
+++ b/fhir-search/src/main/java/org/linuxforhealth/fhir/search/util/SearchHelper.java
@@ -436,7 +436,9 @@ public class SearchHelper {
             if (queryParameters.containsKey(SearchConstants.RESOURCE_TYPE)) {
                 // process all the _type parameters
                 for (String v: queryParameters.get(SearchConstants.RESOURCE_TYPE)) {
-                    List<String> tmpResourceTypes = Arrays.asList(v.split("\\s*,\\s*"));
+                    List<String> tmpResourceTypes = Arrays.stream(v.split(","))
+                            .map(s -> s.trim())
+                            .collect(Collectors.toList());
                     for (String tmpResourceType: tmpResourceTypes) {
                         if (!ModelSupport.isConcreteResourceType(tmpResourceType)) {
                             String msg = "_type parameter has invalid resource type: " + Encode.forHtml(tmpResourceType);

--- a/operation/fhir-operation-bulkdata/src/main/java/org/linuxforhealth/fhir/operation/bulkdata/client/BulkDataClient.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/org/linuxforhealth/fhir/operation/bulkdata/client/BulkDataClient.java
@@ -548,12 +548,12 @@ public class BulkDataClient {
 
         // Export Jobs with data in the exitStatus field
         if (!"COMPLETED".equals(exitStatus) && !"bulkimportchunkjob".equals(executionResponse.getJobName())) {
-            List<String> resourceTypeInfs = Arrays.asList(exitStatus.split("\\s*:\\s*"));
+            List<String> resourceTypeInfs = Arrays.asList(exitStatus.split(":"));
             List<PollingLocationResponse.Output> outputList = new ArrayList<>();
             for (String resourceTypeInf : resourceTypeInfs) {
                 String resourceType = resourceTypeInf.substring(0, resourceTypeInf.indexOf("["));
                 String[] resourceCounts =
-                        resourceTypeInf.substring(resourceTypeInf.indexOf("[") + 1, resourceTypeInf.indexOf("]")).split("\\s*,\\s*");
+                        resourceTypeInf.substring(resourceTypeInf.indexOf("[") + 1, resourceTypeInf.indexOf("]")).split(",");
                 for (int i = 0; i < resourceCounts.length; i++) {
                     StorageType storageType = adapter.getStorageProviderStorageType(source);
                     String sUrl;


### PR DESCRIPTION
To avoid a moderate-level warnings from CodeQL.

In BulkDataClient, we're parsing our own output...there's no reason to expect whitespace.

In SearchHelper.parseQueryParameters I don't think we need to handle type parameter values with whitespace in the list of types either. However, since we already had code to support that, I decided to add a call to trim() after removing whitespace handling from the split.

Signed-off-by: Lee Surprenant <lmsurpre@merative.com>