### PR TITLE
revert to setup-java@v2

### DIFF
--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -65,7 +65,7 @@ jobs:
       with:
         ref: refs/tags/${{ matrix.tag }}
     - name: Setup java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}


### PR DESCRIPTION
Recently I bumped the version to setup-java@v3 and it broke. Something about checking out old tags must have changed between v2 and v3 but I don't have time to look into it right now. So, back to v2 we go.

Signed-off-by: Lee Surprenant <lmsurpre@merative.com>