### PR TITLE
Remove tests

### DIFF
--- a/conformance/fhir-core-r4b/src/test/java/org/linuxforhealth/fhir/core/r4b/test/FHIRRegistryTest.java
+++ b/conformance/fhir-core-r4b/src/test/java/org/linuxforhealth/fhir/core/r4b/test/FHIRRegistryTest.java
@@ -27,24 +27,6 @@ public class FHIRRegistryTest {
     }
 
     @Test
-    public void testGetResourcesByResourceType() {
-        Collection<SearchParameter> searchParameters = FHIRRegistry.getInstance().getResources(SearchParameter.class);
-        Assert.assertEquals(searchParameters.size(), 1414);
-    }
-
-    @Test
-    public void testGetProfilesByType() {
-        Collection<Canonical> observationProfiles = FHIRRegistry.getInstance().getProfiles("Observation");
-        Assert.assertEquals(observationProfiles.size(), 17);
-    }
-
-    @Test
-    public void testGetSearchParametersByType() {
-        Collection<SearchParameter> tokenSearchParameters = FHIRRegistry.getInstance().getSearchParameters("token");
-        Assert.assertEquals(tokenSearchParameters.size(), 566);
-    }
-
-    @Test
     public void testLoadAllResources() {
         // FHIRRegistryUtil has a private set of all definitional resources,
         // so an alternative would be to mark that public and iterate through that instead


### PR DESCRIPTION
Tests should not expect certain number of of resources. Because fhir-registry can be extended  by adding new structure definitions, profiles etc. There can be more than expected resource count.  (For example observationProfiles.size()can be more than 17 )

Signed-off-by: Berkant Karduman <karduman.berkant@gmail.com>