### PR TITLE
Update FHIRPersistenceJDBCImpl.java

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/org/linuxforhealth/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/org/linuxforhealth/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -1912,7 +1912,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
                                 SearchParameter compSP = searchHelper.getSearchParameter(p.getResourceType(), component.getDefinition());
                                 if (compSP == null) {
                                     throw new NullPointerException(String.format("The 'compSP' parameter was " + 
-                                        specified to null [ResourceType=%s,Uri=%s]", p.getResourceType(), component.getDefinition()));
+                                        "specified to null [ResourceType=%s,Uri=%s]", p.getResourceType(), component.getDefinition()));
                                 }                                
                                 JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(p.getResourceType(), compSP);
                                 FHIRPathNode node = nodes.iterator().next();

--- a/fhir-persistence-jdbc/src/main/java/org/linuxforhealth/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/org/linuxforhealth/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -1910,6 +1910,9 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
                                 // Alternatively, we could pull the search parameter from the FHIRRegistry so we can use versioned references.
                                 // However, that would bypass search parameter filtering and so we favor the SeachUtil method here instead.
                                 SearchParameter compSP = searchHelper.getSearchParameter(p.getResourceType(), component.getDefinition());
+                                if(compSP==null){
+                                    throw new NullPointerException(String.format("The 'compSP' parameter was specified to null [ResourceType=%s,Uri=%s]",p.getResourceType(),component.getDefinition()));
+                                }                                
                                 JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(p.getResourceType(), compSP);
                                 FHIRPathNode node = nodes.iterator().next();
                                 if (nodes.size() > 1 ) {

--- a/fhir-persistence-jdbc/src/main/java/org/linuxforhealth/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/org/linuxforhealth/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -1908,10 +1908,11 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
                                 }
 
                                 // Alternatively, we could pull the search parameter from the FHIRRegistry so we can use versioned references.
-                                // However, that would bypass search parameter filtering and so we favor the SeachUtil method here instead.
+                                // However, that would bypass search parameter filtering and so we favor the SeachHelper method here instead.
                                 SearchParameter compSP = searchHelper.getSearchParameter(p.getResourceType(), component.getDefinition());
-                                if(compSP==null){
-                                    throw new NullPointerException(String.format("The 'compSP' parameter was specified to null [ResourceType=%s,Uri=%s]",p.getResourceType(),component.getDefinition()));
+                                if (compSP == null) {
+                                    throw new NullPointerException(String.format("The 'compSP' parameter was " + 
+                                        specified to null [ResourceType=%s,Uri=%s]", p.getResourceType(), component.getDefinition()));
                                 }                                
                                 JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(p.getResourceType(), compSP);
                                 FHIRPathNode node = nodes.iterator().next();


### PR DESCRIPTION
searchHelper.getSearchParameter might return null, and constructure of JDBCParameterBuildingVisitor needs searchParameter. Added new control For checking null reference and create a useful log entry.

Signed-off-by: Berkant Karduman <karduman.berkant@gmail.com>