### PR TITLE
Another `capabilities` change

### DIFF
--- a/fhir-server-test/src/test/java/org/linuxforhealth/fhir/client/test/FHIRClientTest.java
+++ b/fhir-server-test/src/test/java/org/linuxforhealth/fhir/client/test/FHIRClientTest.java
@@ -84,7 +84,7 @@ public class FHIRClientTest extends FHIRClientTestBase {
         assertNotNull(c);
         assertEquals(MIMETYPE_XML, c.getDefaultMimeType());
     }
-    
+
     @Test
     public void testFHIRClientMimeType() throws Exception {
         // The default mimetype should specify FHIR version 4.3, so let's make
@@ -119,7 +119,7 @@ public class FHIRClientTest extends FHIRClientTestBase {
         Parameters.Builder builder = Parameters.builder();
         builder.id(UUID.randomUUID().toString());
         builder.parameter(parameters);
-        
+
         FHIRResponse eraseResponse = client.invoke(Ingredient.class.getSimpleName(), "$erase", ing1.getId(), builder.build());
         assertNotNull(eraseResponse);
         assertResponse(eraseResponse.getResponse(), Response.Status.OK.getStatusCode());
@@ -167,7 +167,7 @@ public class FHIRClientTest extends FHIRClientTestBase {
         assertNotNull(conf.getFormat());
         assertEquals(6, conf.getFormat().size());
         assertNotNull(conf.getVersion());
-        assertNotNull(conf.getName());
+        assertNotNull(conf.getTitle());
         assertNotNull(conf.getInstantiates());
         boolean foundBulkdata = false;
         for (Canonical instantiate : conf.getInstantiates()) {
@@ -193,7 +193,7 @@ public class FHIRClientTest extends FHIRClientTestBase {
         assertNotNull(conf.getFormat());
         assertEquals(6, conf.getFormat().size());
         assertNotNull(conf.getVersion());
-        assertNotNull(conf.getName());
+        assertNotNull(conf.getTitle());
         assertNotNull(conf.getInstantiates());
         boolean foundBulkdata = false;
         for (Canonical instantiate : conf.getInstantiates()) {

--- a/fhir-server-test/src/test/java/org/linuxforhealth/fhir/server/test/BasicServerTest.java
+++ b/fhir-server-test/src/test/java/org/linuxforhealth/fhir/server/test/BasicServerTest.java
@@ -26,28 +26,21 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.testng.annotations.Test;
-
 import org.linuxforhealth.fhir.core.FHIRMediaType;
 import org.linuxforhealth.fhir.model.format.Format;
 import org.linuxforhealth.fhir.model.generator.FHIRGenerator;
 import org.linuxforhealth.fhir.model.resource.Bundle;
 import org.linuxforhealth.fhir.model.resource.Bundle.Entry;
 import org.linuxforhealth.fhir.model.resource.CapabilityStatement;
-import org.linuxforhealth.fhir.model.resource.Immunization;
 import org.linuxforhealth.fhir.model.resource.Observation;
 import org.linuxforhealth.fhir.model.resource.OperationOutcome;
 import org.linuxforhealth.fhir.model.resource.OperationOutcome.Issue;
 import org.linuxforhealth.fhir.model.resource.Patient;
-import org.linuxforhealth.fhir.model.resource.Resource;
 import org.linuxforhealth.fhir.model.resource.TerminologyCapabilities;
 import org.linuxforhealth.fhir.model.test.TestUtil;
 import org.linuxforhealth.fhir.model.type.ContactPoint;
-import org.linuxforhealth.fhir.model.type.Narrative;
-import org.linuxforhealth.fhir.model.type.Xhtml;
 import org.linuxforhealth.fhir.model.type.code.ContactPointSystem;
 import org.linuxforhealth.fhir.model.type.code.ContactPointUse;
-import org.linuxforhealth.fhir.model.type.code.NarrativeStatus;
 import org.linuxforhealth.fhir.path.FHIRPathBooleanValue;
 import org.linuxforhealth.fhir.path.FHIRPathNode;
 import org.linuxforhealth.fhir.path.evaluator.FHIRPathEvaluator;
@@ -56,6 +49,7 @@ import org.linuxforhealth.fhir.path.exception.FHIRPathException;
 import org.linuxforhealth.fhir.validation.FHIRValidator;
 import org.linuxforhealth.fhir.validation.exception.FHIRValidationException;
 import org.linuxforhealth.fhir.validation.util.FHIRValidationUtil;
+import org.testng.annotations.Test;
 
 import jakarta.json.JsonObject;
 
@@ -81,7 +75,7 @@ public class BasicServerTest extends FHIRServerTestBase {
         assertNotNull(conf.getFormat());
         assertEquals(conf.getFormat().size(), 6);
         assertNotNull(conf.getVersion());
-        assertNotNull(conf.getName());
+        assertNotNull(conf.getTitle());
 
         FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
         EvaluationContext evaluationContext = new EvaluationContext(conf);
@@ -122,7 +116,7 @@ public class BasicServerTest extends FHIRServerTestBase {
         TerminologyCapabilities conf = response.readEntity(TerminologyCapabilities.class);
         assertNotNull(conf);
         assertNotNull(conf.getVersion());
-        assertNotNull(conf.getName());
+        assertNotNull(conf.getTitle());
 
         FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
         EvaluationContext evaluationContext = new EvaluationContext(conf);
@@ -168,7 +162,7 @@ public class BasicServerTest extends FHIRServerTestBase {
         assertNotNull(conf.getFormat());
         assertEquals(conf.getFormat().size(), 6);
         assertNotNull(conf.getVersion());
-        assertNotNull(conf.getName());
+        assertNotNull(conf.getTitle());
     }
 
     /**
@@ -188,7 +182,7 @@ public class BasicServerTest extends FHIRServerTestBase {
         assertNotNull(conf.getFormat());
         assertEquals(conf.getFormat().size(), 6);
         assertNotNull(conf.getVersion());
-        assertNotNull(conf.getName());
+        assertNotNull(conf.getTitle());
     }
 
     /**

--- a/fhir-server/src/main/java/org/linuxforhealth/fhir/server/resources/Capabilities.java
+++ b/fhir-server/src/main/java/org/linuxforhealth/fhir/server/resources/Capabilities.java
@@ -230,12 +230,12 @@ public class Capabilities extends FHIRResource {
         TerminologyCapabilities.Implementation impl;
         if (customTerminologyImpl != null) {
             impl = TerminologyCapabilities.Implementation.builder()
-                    .description(string(buildDescription))
+                    .description(buildDescription)
                     .url(org.linuxforhealth.fhir.model.type.Url.of(customTerminologyImpl))
                     .build();
         } else {
             impl = TerminologyCapabilities.Implementation.builder()
-                    .description(string(buildDescription))
+                    .description(buildDescription)
                     .build();
         }
 
@@ -244,13 +244,13 @@ public class Capabilities extends FHIRResource {
             .experimental(org.linuxforhealth.fhir.model.type.Boolean.TRUE)
             .date(DateTime.now(ZoneOffset.UTC))
             .kind(CapabilityStatementKind.INSTANCE)
-            .version(string(buildInfo.getBuildVersion()))
-            .name(string(FHIR_SERVER_NAME))
+            .version(buildInfo.getBuildVersion())
+            .title(FHIR_SERVER_NAME)
             .description(Markdown.of(buildDescription))
             .copyright(Markdown.of(FHIR_COPYRIGHT))
             .software(TerminologyCapabilities.Software.builder()
-                .name(string(FHIR_SERVER_NAME))
-                .version(string(buildInfo.getBuildVersion()))
+                .name(FHIR_SERVER_NAME)
+                .version(buildInfo.getBuildVersion())
                 .id(buildInfo.getBuildId())
                 .build())
             .implementation(impl)
@@ -284,7 +284,7 @@ public class Capabilities extends FHIRResource {
             List<TerminologyCapabilities.CodeSystem.Version> versions = versionMap.computeIfAbsent(url, k -> new ArrayList<>());
             if (!Version.NO_VERSION.equals(version)) {
                 versions.add(TerminologyCapabilities.CodeSystem.Version.builder()
-                    .code(string(version.toString()))
+                    .code(version.toString())
                     .isDefault(registryResource.isDefaultVersion() ? org.linuxforhealth.fhir.model.type.Boolean.TRUE : null)
                     .build());
             }
@@ -516,7 +516,7 @@ public class Capabilities extends FHIRResource {
                         .code(Code.of(smartEnabled ? "SMART-on-FHIR" : "OAuth"))
                         .system(Uri.of("http://terminology.hl7.org/CodeSystem/restful-security-service"))
                         .build())
-                    .text(smartEnabled ? string("OAuth") : string("OAuth2 using SMART-on-FHIR profile (see http://docs.smarthealthit.org)"))
+                    .text(smartEnabled ? "OAuth" : "OAuth2 using SMART-on-FHIR profile (see http://docs.smarthealthit.org)")
                     .build())
                 .extension(buildOAuthURIsExtension(authURL, tokenURL, regURL, manageURL, introspectURL, revokeURL));
         }
@@ -549,12 +549,12 @@ public class Capabilities extends FHIRResource {
         CapabilityStatement.Implementation impl;
         if (customImpl != null) {
             impl = CapabilityStatement.Implementation.builder()
-                    .description(string(buildDescription))
+                    .description(buildDescription)
                     .url(org.linuxforhealth.fhir.model.type.Url.of(customImpl))
                     .build();
         } else {
             impl = CapabilityStatement.Implementation.builder()
-                    .description(string(buildDescription))
+                    .description(buildDescription)
                     .build();
         }
 
@@ -568,13 +568,13 @@ public class Capabilities extends FHIRResource {
                 .patchFormat(Code.of(FHIRMediaType.APPLICATION_JSON_PATCH),
                              Code.of(FHIRMediaType.APPLICATION_FHIR_JSON),
                              Code.of(FHIRMediaType.APPLICATION_FHIR_XML))
-                .version(string(buildInfo.getBuildVersion()))
-                .name(string(FHIR_SERVER_NAME))
+                .version(buildInfo.getBuildVersion())
+                .title(FHIR_SERVER_NAME)
                 .description(Markdown.of(buildDescription))
                 .copyright(Markdown.of(FHIR_COPYRIGHT))
                 .software(CapabilityStatement.Software.builder()
-                          .name(string(FHIR_SERVER_NAME))
-                          .version(string(buildInfo.getBuildVersion()))
+                          .name(FHIR_SERVER_NAME)
+                          .version(buildInfo.getBuildVersion())
                           .id(buildInfo.getBuildId())
                           .build())
                 .rest(rest)
@@ -764,25 +764,25 @@ public class Capabilities extends FHIRResource {
         List<Extension> extentions = new ArrayList<>();
         Extension extension = Extension.builder()
                 .url(EXT_BASE + "defaultTenantId")
-                .value(string(fhirConfig.getStringProperty(FHIRConfiguration.PROPERTY_DEFAULT_TENANT_ID, FHIRConfiguration.DEFAULT_TENANT_ID)))
+                .value(fhirConfig.getStringProperty(FHIRConfiguration.PROPERTY_DEFAULT_TENANT_ID, FHIRConfiguration.DEFAULT_TENANT_ID))
                 .build();
         extentions.add(extension);
 
         extension = Extension.builder()
                 .url(EXT_BASE + "websocketNotificationsEnabled")
-                .value(org.linuxforhealth.fhir.model.type.Boolean.of(fhirConfig.getBooleanProperty(FHIRConfiguration.PROPERTY_WEBSOCKET_ENABLED, Boolean.FALSE)))
+                .value(fhirConfig.getBooleanProperty(FHIRConfiguration.PROPERTY_WEBSOCKET_ENABLED, Boolean.FALSE))
                 .build();
         extentions.add(extension);
 
         extension = Extension.builder()
                 .url(EXT_BASE + "kafkaNotificationsEnabled")
-                .value(org.linuxforhealth.fhir.model.type.Boolean.of(fhirConfig.getBooleanProperty(FHIRConfiguration.PROPERTY_KAFKA_ENABLED, Boolean.FALSE)))
+                .value(fhirConfig.getBooleanProperty(FHIRConfiguration.PROPERTY_KAFKA_ENABLED, Boolean.FALSE))
                 .build();
         extentions.add(extension);
 
         extension = Extension.builder()
                 .url(EXT_BASE + "natsNotificationsEnabled")
-                .value(org.linuxforhealth.fhir.model.type.Boolean.of(fhirConfig.getBooleanProperty(FHIRConfiguration.PROPERTY_NATS_ENABLED, Boolean.FALSE)))
+                .value(fhirConfig.getBooleanProperty(FHIRConfiguration.PROPERTY_NATS_ENABLED, Boolean.FALSE))
                 .build();
         extentions.add(extension);
 
@@ -793,7 +793,7 @@ public class Capabilities extends FHIRResource {
 
         extension = Extension.builder()
                 .url(EXT_BASE + "notificationResourceTypes")
-                .value(string(notificationResourceTypes))
+                .value(notificationResourceTypes)
                 .build();
         extentions.add(extension);
 
@@ -809,13 +809,13 @@ public class Capabilities extends FHIRResource {
 
         extension = Extension.builder()
                 .url(EXT_BASE + "auditLogServiceName")
-                .value(string(auditLogServiceName))
+                .value(auditLogServiceName)
                 .build();
         extentions.add(extension);
 
         extension = Extension.builder()
                 .url(EXT_BASE + "persistenceType")
-                .value(string(getPersistenceImpl().getClass().getSimpleName()))
+                .value(getPersistenceImpl().getClass().getSimpleName())
                 .build();
         extentions.add(extension);
 


### PR DESCRIPTION
The HL7 validator issues a warning on our current CapabilityStatement because `name` is intended for computer processing (so they recommend against whitespace but still allow it).

`CapabilityStatement.title` is the field intended for human consumption and so I think its cleaner to use that instead.

I also removed the no-longer-needed calls to the static `string()` factory...because thats what I do.

Signed-off-by: Lee Surprenant <lmsurpre@merative.com>