### PR TITLE
bump node.js version in the site workflow

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
         matrix:
-            node-version: [14.x]
+            node-version: [18.x]
 
     steps:
     - name: Grab the main Branch


### PR DESCRIPTION
node 14.x is in maintenance and doesn't seem well supported by github actions any more

node 18.x went LTS 2022-10-25

Signed-off-by: Lee Surprenant <lmsurpre@merative.com>