### PR TITLE
Formulary fixes

### DIFF
--- a/conformance/fhir-ig-davinci-pdex-formulary/CHANGELOG.md
+++ b/conformance/fhir-ig-davinci-pdex-formulary/CHANGELOG.md
@@ -23,6 +23,7 @@ Source - http://hl7.org/fhir/us/davinci-drug-formulary/STU1.1 retrieved on May 2
 Source - http://hl7.org/fhir/us/davinci-drug-formulary/STU2/ retrieved on September 05, 2022.
 - Modified ig-r4.json to remove parameters that aren't valid in FHIR R4
 - Stripped narrative text to reduce the size and formatted the JSON contents (both via the ResourceProcessor tool)
+- Fixed the code for SearchParameter-Basic-subject.json (per https://jira.hl7.org/browse/FHIR-39401)
 
 # Steps to update
 1. download the npm package for whatever version of PDEX US Drug Formulary you want (and note what downloads we used from where in this file)

--- a/conformance/fhir-ig-davinci-pdex-formulary/src/main/resources/hl7/fhir/us/davinci-pdex-formulary/200/package/SearchParameter-Basic-subject.json
+++ b/conformance/fhir-ig-davinci-pdex-formulary/src/main/resources/hl7/fhir/us/davinci-pdex-formulary/200/package/SearchParameter-Basic-subject.json
@@ -37,7 +37,7 @@
             ]
         }
     ],
-    "code": "code",
+    "code": "subject",
     "base": [
         "Basic"
     ],

--- a/conformance/fhir-ig-davinci-pdex-formulary/src/main/resources/hl7/fhir/us/davinci-pdex-formulary/200/package/StructureDefinition-usdf-PayerInsurancePlan.json
+++ b/conformance/fhir-ig-davinci-pdex-formulary/src/main/resources/hl7/fhir/us/davinci-pdex-formulary/200/package/StructureDefinition-usdf-PayerInsurancePlan.json
@@ -908,7 +908,7 @@
                 "isSummary": true,
                 "binding": {
                     "strength": "extensible",
-                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/InsuranceProductTypeVS|2.0.0"
+                    "valueSet": "http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/InsuranceProductTypeVS|1.0.0"
                 },
                 "mapping": [
                     {


### PR DESCRIPTION
1. fixed the version suffix on the reference to http://hl7.org/fhir/us/davinci-pdex-plan-net/ValueSet/InsuranceProductTypeVS
2. fixed the "code" in SearchParameter-Basic-subject.json (and opened a corresponding spec bug, https://jira.hl7.org/browse/FHIR-39401 )

Signed-off-by: Lee Surprenant <lmsurpre@merative.com>