### PR TITLE
Issue 4202

### DIFF
--- a/fhir-server-spi/src/main/java/org/linuxforhealth/fhir/server/spi/operation/AbstractOperation.java
+++ b/fhir-server-spi/src/main/java/org/linuxforhealth/fhir/server/spi/operation/AbstractOperation.java
@@ -9,6 +9,8 @@ package org.linuxforhealth.fhir.server.spi.operation;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.logging.Logger;
+import java.util.StringJoiner;
 
 import org.linuxforhealth.fhir.exception.FHIROperationException;
 import org.linuxforhealth.fhir.model.resource.OperationDefinition;
@@ -24,6 +26,7 @@ import org.linuxforhealth.fhir.model.util.ModelSupport;
 import org.linuxforhealth.fhir.search.util.SearchHelper;
 
 public abstract class AbstractOperation implements FHIROperation {
+    private static final Logger LOGGER = Logger.getLogger(AbstractOperation.class.getName());
     protected final OperationDefinition definition;
 
     public AbstractOperation() {
@@ -209,6 +212,7 @@ public abstract class AbstractOperation implements FHIROperation {
                 for (OperationDefinition.Parameter odParameter : operationDefinition.getParameter()) {
                     if (parameter.getName().getValue() != null && odParameter.getName() != null
                             && parameter.getName().getValue().equals(odParameter.getName().getValue())
+                            && odParameter.getUse().equals(OperationParameterUse.IN)
                             && (odParameter.getType() == null || !ModelSupport.isPrimitiveType(ModelSupport.getDataType(odParameter.getType().getValue()))
                                     || (odParameter.getPart() != null && !odParameter.getPart().isEmpty()))) {
                         return false;

--- a/fhir-server-spi/src/main/java/org/linuxforhealth/fhir/server/spi/operation/AbstractOperation.java
+++ b/fhir-server-spi/src/main/java/org/linuxforhealth/fhir/server/spi/operation/AbstractOperation.java
@@ -9,8 +9,6 @@ package org.linuxforhealth.fhir.server.spi.operation;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.logging.Logger;
-import java.util.StringJoiner;
 
 import org.linuxforhealth.fhir.exception.FHIROperationException;
 import org.linuxforhealth.fhir.model.resource.OperationDefinition;
@@ -26,7 +24,6 @@ import org.linuxforhealth.fhir.model.util.ModelSupport;
 import org.linuxforhealth.fhir.search.util.SearchHelper;
 
 public abstract class AbstractOperation implements FHIROperation {
-    private static final Logger LOGGER = Logger.getLogger(AbstractOperation.class.getName());
     protected final OperationDefinition definition;
 
     public AbstractOperation() {
@@ -212,7 +209,7 @@ public abstract class AbstractOperation implements FHIROperation {
                 for (OperationDefinition.Parameter odParameter : operationDefinition.getParameter()) {
                     if (parameter.getName().getValue() != null && odParameter.getName() != null
                             && parameter.getName().getValue().equals(odParameter.getName().getValue())
-                            && odParameter.getUse().equals(OperationParameterUse.IN)
+                            && odParameter.getUse().getValueAsEnum().equals(OperationParameterUse.IN)
                             && (odParameter.getType() == null || !ModelSupport.isPrimitiveType(ModelSupport.getDataType(odParameter.getType().getValue()))
                                     || (odParameter.getPart() != null && !odParameter.getPart().isEmpty()))) {
                         return false;

--- a/term/fhir-term/src/main/java/org/linuxforhealth/fhir/term/service/FHIRTermService.java
+++ b/term/fhir-term/src/main/java/org/linuxforhealth/fhir/term/service/FHIRTermService.java
@@ -414,7 +414,7 @@ public class FHIRTermService {
      */
     public LookupOutcome lookup(Coding coding, LookupParameters parameters) {
         if (!LookupParameters.EMPTY.equals(parameters)) {
-            throw new UnsupportedOperationException("Lookup parameters are not suppored");
+            throw new UnsupportedOperationException("Lookup parameters are not supported");
         }
         java.lang.String system = (coding.getSystem() != null) ? coding.getSystem().getValue() : null;
         java.lang.String version = (coding.getVersion() != null) ? coding.getVersion().getValue() : null;


### PR DESCRIPTION
#4202 

Fixed issue in **org.linuxforhealth.fhir.server.spi.operation.AbstractOperation::isGetMethodAllowed** causing *out parameters* of *operation definition* to be checked as well leading to unexpected response messages.