### PR TITLE
Schematool: allow `-` in database usernames

### DIFF
--- a/fhir-database-utils/src/main/java/org/linuxforhealth/fhir/database/utils/common/DataDefinitionUtil.java
+++ b/fhir-database-utils/src/main/java/org/linuxforhealth/fhir/database/utils/common/DataDefinitionUtil.java
@@ -21,7 +21,7 @@ import org.linuxforhealth.fhir.database.utils.model.OrderedColumnDef;
  * Handles common syntax for generating DDL
  */
 public class DataDefinitionUtil {
-    private static final String NAME_PATTERN_RGX = "[a-zA-Z_]\\w*$";
+    private static final String NAME_PATTERN_RGX = "[a-zA-Z_][-\\w]*$";
     private static final Pattern NAME_PATTERN = Pattern.compile(NAME_PATTERN_RGX);
 
     /**


### PR DESCRIPTION
Solves #4193 

When there are dashes (-) in the Postgres username, the schematool fails with an exception. In Postgres, dashes are legal in usernames, so the verifying pattern is adapted accordingly.