### PR TITLE
compositeId filled for reference type search parameters

### DIFF
--- a/fhir-database-utils/src/main/java/org/linuxforhealth/fhir/database/utils/common/DataDefinitionUtil.java
+++ b/fhir-database-utils/src/main/java/org/linuxforhealth/fhir/database/utils/common/DataDefinitionUtil.java
@@ -21,7 +21,7 @@ import org.linuxforhealth.fhir.database.utils.model.OrderedColumnDef;
  * Handles common syntax for generating DDL
  */
 public class DataDefinitionUtil {
-    private static final String NAME_PATTERN_RGX = "[a-zA-Z_][-\\w]*$";
+    private static final String NAME_PATTERN_RGX = "[a-zA-Z_][\\w]*$";
     private static final Pattern NAME_PATTERN = Pattern.compile(NAME_PATTERN_RGX);
 
     /**

--- a/fhir-persistence-params/src/main/java/org/linuxforhealth/fhir/persistence/params/database/PlainBatchParameterProcessor.java
+++ b/fhir-persistence-params/src/main/java/org/linuxforhealth/fhir/persistence/params/database/PlainBatchParameterProcessor.java
@@ -333,7 +333,7 @@ public class PlainBatchParameterProcessor implements IBatchParameterProcessor {
 
         try {
             PlainPostgresParameterBatch dao = getParameterBatchDao(resourceType);
-            dao.addReference(logicalResourceId, parameterNameValue.getParameterNameId(), refLogicalResourceId.getLogicalResourceId(), parameter.getRefVersionId());
+            dao.addReference(logicalResourceId, parameterNameValue.getParameterNameId(), refLogicalResourceId.getLogicalResourceId(), parameter.getRefVersionId(),parameter.getCompositeId());
         } catch (SQLException x) {
             throw new FHIRPersistenceException("Failed inserting security params for '" + resourceType + "'");
         }

--- a/fhir-persistence-params/src/main/java/org/linuxforhealth/fhir/persistence/params/database/PlainPostgresParameterBatch.java
+++ b/fhir-persistence-params/src/main/java/org/linuxforhealth/fhir/persistence/params/database/PlainPostgresParameterBatch.java
@@ -516,11 +516,11 @@ public class PlainPostgresParameterBatch {
      * @param refLogicalResourceId
      * @param refVersionId
      */
-    public void addReference(long logicalResourceId, int parameterNameId, long refLogicalResourceId, Integer refVersionId) throws SQLException {
+    public void addReference(long logicalResourceId, int parameterNameId, long refLogicalResourceId, Integer refVersionId,Integer compositeId) throws SQLException {
         logger.fine(() -> "Adding reference: parameterNameId:" + parameterNameId + " refLogicalResourceId:" + refLogicalResourceId + " refVersionId:" + refVersionId);
         if (refs == null) {
             final String tablePrefix = resourceType.toLowerCase();
-            final String insertString = "INSERT INTO " + tablePrefix + "_ref_values (parameter_name_id, logical_resource_id, ref_logical_resource_id, ref_version_id) VALUES (?,?,?,?)";
+            final String insertString = "INSERT INTO " + tablePrefix + "_ref_values (parameter_name_id, logical_resource_id, ref_logical_resource_id, ref_version_id,composite_id) VALUES (?,?,?,?,?)";
             refs = connection.prepareStatement(insertString);
         }
         PreparedStatementHelper psh = new PreparedStatementHelper(refs);
@@ -528,6 +528,7 @@ public class PlainPostgresParameterBatch {
             .setLong(logicalResourceId)
             .setLong(refLogicalResourceId)
             .setInt(refVersionId)
+            .setInt(compositeId)
             .addBatch();
         refCount++;
     }


### PR DESCRIPTION
Composite search parameters with reference types were not working properly. 
This PR closes the issue  #4242 

testInvalidComment test was failing because of the NAME_PATTERN. The pattern reverted back to the previous version.